### PR TITLE
Render Atom feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.pygments-cache/
+.tweet-cache/
+_site/

--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,4 @@
 ---
-layout: nil
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/atom.xml
+++ b/atom.xml
@@ -1,4 +1,5 @@
 ---
+content_type: text/xml
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
A few final changes to the `atom.xml` frontmatter to finish the rendering of the RSS feed (deconst/deconst-docs#74).