### PR TITLE
Trim the extra slash from the RSS feed URLs.

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -5,8 +5,8 @@ content_type: text/xml
 <feed xmlns="http://www.w3.org/2005/Atom">
 
   <title><![CDATA[{{ site.name }}]]></title>
-  <link href="{{ site.url }}/atom.xml" rel="self"/>
-  <link href="{{ site.url }}/"/>
+  <link href="{{ site.url }}atom.xml" rel="self"/>
+  <link href="{{ site.url }}"/>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ site.url }}/</id>
 


### PR DESCRIPTION
This was breaking requests from the Atom feed with deconst (as a result of a different bug).