### PR TITLE
Fix links to .NET QuickStart topics

### DIFF
--- a/_posts/2015-07-13-openstacknet-1.4-and-beyond.md
+++ b/_posts/2015-07-13-openstacknet-1.4-and-beyond.md
@@ -19,7 +19,7 @@ categories:
 
 [Rackspace CDN](http://www.rackspace.com/cloud/cdn-content-delivery-network/features) allows you to add a CDN service to your existing website with a single API call. The service pulls content from your website and caches it on Akamai's global network. From there you can control caching rules, restrict access, and purge cached content.
 
-The following small example helps you to get started. The [QuickStart for Rackspace CDN](https://developer.rackspace.com/docs/cdn/getting-started/?lang=dot-net) has a complete walk-through, and you can download the example project from the [OpenStack.NET Demo repository](https://github.com/openstacknetsdk/Demos/tree/master/RackspaceQuickstart).
+The following small example helps you to get started. The [QuickStart for Rackspace CDN](https://developer.rackspace.com/docs/cdn/getting-started/?lang=.net) has a complete walk-through, and you can download the example project from the [OpenStack.NET Demo repository](https://github.com/openstacknetsdk/Demos/tree/master/RackspaceQuickstart).
 
 ```csharp
 var cdnService = new ContentDeliveryNetworkService(authProvider, region);

--- a/sdks/dot-net/index.html
+++ b/sdks/dot-net/index.html
@@ -7,16 +7,16 @@ title: .NET SDK
   <p>Rackspace's official OpenStack SDK for Microsoft .NET, <a href="http://openstacknetsdk.org">OpenStack.NET</a>, an MIT licensed open-source community project for using multiple cloud providers from a standardized API.</p>
   <p>Currently, OpenStack.NET has support for multiple Rackspace services:</p>
    <ul>
-    <li><a href="/docs/auto-scale/getting-started/?lang=dot-net">Auto Scale</a></li>
-    <li><a href="/docs/cdn/getting-started/?lang=dot-net">CDN</a></li>
-    <li><a href="/docs/cloud-block-storage/getting-started/?lang=dot-net">Cloud Block Storage</a></li>
-    <li><a href="/docs/cloud-dns/getting-started/?lang=dot-net">Cloud DNS</a></li>
-    <li><a href="/docs/cloud-databases/getting-started/?lang=dot-net">Cloud Databases</a></li>
-    <li><a href="/docs/cloud-files/getting-started/?lang=dot-net">Cloud Files</a></li>
-    <li><a href="/docs/cloud-load-balancers/getting-started/?lang=dot-net">Cloud Load Balancers</a></li>
-    <li><a href="/docs/cloud-monitoring/getting-started/?lang=dot-net">Cloud Monitoring</a></li>
-    <li><a href="/docs/cloud-queues/getting-started/?lang=dot-net">Cloud Queues</a></li>
-    <li><a href="/docs/cloud-servers/getting-started/?lang=dot-net">Cloud Servers</a></li>
+    <li><a href="/docs/auto-scale/getting-started/?lang=.net">Auto Scale</a></li>
+    <li><a href="/docs/cdn/getting-started/?lang=.net">CDN</a></li>
+    <li><a href="/docs/cloud-block-storage/getting-started/?lang=.net">Cloud Block Storage</a></li>
+    <li><a href="/docs/cloud-dns/getting-started/?lang=.net">Cloud DNS</a></li>
+    <li><a href="/docs/cloud-databases/getting-started/?lang=.net">Cloud Databases</a></li>
+    <li><a href="/docs/cloud-files/getting-started/?lang=.net">Cloud Files</a></li>
+    <li><a href="/docs/cloud-load-balancers/getting-started/?lang=.net">Cloud Load Balancers</a></li>
+    <li><a href="/docs/cloud-monitoring/getting-started/?lang=.net">Cloud Monitoring</a></li>
+    <li><a href="/docs/cloud-queues/getting-started/?lang=.net">Cloud Queues</a></li>
+    <li><a href="/docs/cloud-servers/getting-started/?lang=.net">Cloud Servers</a></li>
    </ul>
   <p>Support for additional services is on-going.</p>
   <hr />
@@ -61,13 +61,3 @@ foreach (Server server in servers)
     <li>IRC: #rackspace-dev on Freenode</li>
   </ul>
 </div>
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
The links were using `dot-net` instead of `.net` for the language in the query string which caused the wrong language to be displayed in the QuickStart.