### PR TITLE
Include a _deconst.json config.

### DIFF
--- a/_deconst.json
+++ b/_deconst.json
@@ -1,0 +1,3 @@
+{
+  "contentIDBase": "https://github.com/rackerlabs/docs-developer-blog"
+}


### PR DESCRIPTION
Provide the CONTENT_ID_BASE in a `_deconst.json` file, as implemented by deconst/preparer-jekyll#15.