### PR TITLE
Flag XML documents as unsearchable.

### DIFF
--- a/_includes/custom/category_feed.xml
+++ b/_includes/custom/category_feed.xml
@@ -1,4 +1,5 @@
 ---
+unsearchable: true
 content_type: text/xml
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/atom.xml
+++ b/atom.xml
@@ -1,4 +1,5 @@
 ---
+unsearchable: true
 content_type: text/xml
 ---
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
This'll exclude them from Elasticsearch indexing.