### PR TITLE
Clean up blog categories

### DIFF
--- a/_posts/2012-08-21-git-init.markdown
+++ b/_posts/2012-08-21-git-init.markdown
@@ -1,9 +1,9 @@
 ---
 comments: true
 sharing: true
-date: 2012-08-21 15:23:48
+date: 2012-08-21T15:23:48.000Z
 layout: post
-title: "git init"
+title: git init
 author: Wayne Walls
 categories:
   - General

--- a/_posts/2012-08-21-git-init.markdown
+++ b/_posts/2012-08-21-git-init.markdown
@@ -6,7 +6,7 @@ layout: post
 title: "git init"
 author: Wayne Walls
 categories:
-- General
+  - General
 ---
 
 Our cloud is [open](http://www.rackspace.com/cloud/openstack/). We believe our company should be too. One of our [Core Values](http://rackertalent.com/people/core-values/) at Rackspace is full disclosure and transparency, and we want to build a community for our developers that is open, transparent and helps them build amazing applications on the open cloud.

--- a/_posts/2012-08-23-getting-started-using-python-novaclient-to-manage-cloud-servers.markdown
+++ b/_posts/2012-08-23-getting-started-using-python-novaclient-to-manage-cloud-servers.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
 sharing: true
-date: 2012-08-23 08:47:54
+date: 2012-08-23T08:47:54.000Z
 layout: post
-title: "Getting Started: Using rackspace-novaclient to manage Cloud Servers"
+title: 'Getting Started: Using rackspace-novaclient to manage Cloud Servers'
 author: Hart Hoover
 categories:
-- Cloud Servers
+  - Cloud Servers
 ---
 
 Using the [Rackspace Cloud Control Panel](http://www.rackspace.com/knowledge_center/article/introducing-the-next-generation-cloud-control-panel) to manage your servers is awesome, but sometimes you just need to get a simple thing done quickly via the command line. Enter the OpenStack [rackspace-novaclient](http://pypi.python.org/pypi/rackspace-novaclient/1.0), a CLI tool to manage your Cloud Servers.

--- a/_posts/2012-08-27-using-raxmon-to-configure-rackspace-cloud-monitoring.markdown
+++ b/_posts/2012-08-27-using-raxmon-to-configure-rackspace-cloud-monitoring.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
 sharing: true
-date: 2012-08-27 15:02:25
+date: 2012-08-27T15:02:25.000Z
 layout: post
 author: Wayne Walls
 title: Using raxmon to configure Rackspace Cloud Monitoring
 categories:
-- Cloud Monitoring
+  - Cloud Monitoring
 ---
 
 With the [launch](http://www.rackspace.com/blog/monitor-any-cloud-or-web-infrastructure-with-new-rackspace-cloud-monitoring-now-in-unlimited-availability/) of Rackspace Cloud Monitoring (RCM) earlier this week, Rackspace has added an additional tool to your belt that shows you how your servers and applications are behaving. Cloud Monitoring makes it easy to configure monitors and alerts from the Control Panel, but today I want to focus on raxmon, one of the most flexible CLI tools available today for RCM.

--- a/_posts/2012-08-28-welcome-mailgun.markdown
+++ b/_posts/2012-08-28-welcome-mailgun.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
 sharing: true
-date: 2012-08-28 08:52:28
+date: 2012-08-28T08:52:28.000Z
 layout: post
 author: Hart Hoover
-title: Welcome, Mailgun!
+title: 'Welcome, Mailgun!'
 categories:
-- Mailgun
+  - Mailgun
 ---
 
 

--- a/_posts/2012-09-04-using-puppet-with-cloud-servers.markdown
+++ b/_posts/2012-09-04-using-puppet-with-cloud-servers.markdown
@@ -1,13 +1,13 @@
 ---
 comments: true
 sharing: true
-date: 2012-09-04 08:47:56
+date: 2012-09-04T08:47:56.000Z
 layout: post
 title: Using Puppet with Cloud Servers
 author: Hart Hoover
 categories:
-- Cloud Servers
-- Puppet
+  - Cloud Servers
+  - Puppet
 ---
 
 Many of our customers use configuration management packages to manage their cloud infrastructure. These packages include Opscode's [Chef](http://www.opscode.com/chef/), [CFEngine](http://cfengine.com/), Red Hat's [Spacewalk](http://spacewalk.redhat.com/), and Puppet Labs' [Puppet](http://puppetlabs.com/puppet/what-is-puppet/). Here, I'll dive into Puppet to show you how easy it is to manage Cloud Servers using a configuration management solution. We're going to create two servers: a puppetmaster and a client server running puppet.

--- a/_posts/2012-09-05-node-js-a-peek-under-the-hood.markdown
+++ b/_posts/2012-09-05-node-js-a-peek-under-the-hood.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
 sharing: true
-date: 2012-09-05 08:00:22
+date: 2012-09-05T08:00:22.000Z
 layout: post
 title: node.js - a peek under the hood
 author: Wayne Walls
 categories:
-- Cloud Servers
+  - Cloud Servers
 ---
 
 Greetings, friends! Today I want to touch on a "fairly" new programming language, Node.js. In this case, "fairly new" means it was created in 2009. [Ryan Dahl](https://twitter.com/ryah) created Node.js because he desired the ability to make web sites with push capabilities like those seen in popular web applications like Gmail. So what is Node.js, exactly? Node.js is a framework for building networked applications in JavaScript outside of the browser. It leverages [V8](http://code.google.com/p/v8/), the super fast JavaScript engine by Google. JavaScript is a great fit for writing servers due to its event-driven nature. You not only benefit from the speed of V8, but most of the time, the Node.js/JavaScript paradigms make you write code that is fast by design.

--- a/_posts/2012-09-07-using-libcloud-and-puppet-to-bootstrap-cloud-servers.markdown
+++ b/_posts/2012-09-07-using-libcloud-and-puppet-to-bootstrap-cloud-servers.markdown
@@ -1,14 +1,14 @@
 ---
 comments: true
 sharing: true
-date: 2012-09-07 08:00:27
+date: 2012-09-07T08:00:27.000Z
 layout: post
 title: Using libcloud and Puppet to bootstrap Cloud Servers
 author: Hart Hoover
 categories:
-- Cloud Servers
-- Puppet
-- Python
+  - Cloud Servers
+  - Puppet
+  - Python
 ---
 
 In my [last post](http://devops.rackspace.com/using-puppet-with-cloud-servers.html), I discussed a manual install of Puppet between a puppetmaster and client. Here, I will take that a step further and use Apache [libcloud](http://libcloud.apache.org/) to bootstap a Puppet client node.

--- a/_posts/2012-09-10-cloud-connect-chicago-2012.markdown
+++ b/_posts/2012-09-10-cloud-connect-chicago-2012.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-09-10 08:00:36
+date: 2012-09-10T08:00:36.000Z
 layout: post
 title: 'Cloud Connect 2012: Chicago'
 author: Hart Hoover
 categories:
-- General
+  - General
 ---
 
 Rackspace will be present at [Cloud Connect](http://www.cloudconnectevent.com/chicago/) in Chicago this week! If you're a Rackspace customer we would love for you to stop by our booth and talk to us about how your company uses the [Open Cloud](http://rackspace.com/cloud). We also have several Rackers speaking during the conference:

--- a/_posts/2012-09-12-rackspace-open-sources-atom-nuke-the-fast-atom-framework.markdown
+++ b/_posts/2012-09-12-rackspace-open-sources-atom-nuke-the-fast-atom-framework.markdown
@@ -1,12 +1,11 @@
 ---
 comments: true
-date: 2012-09-12 13:13:50
+date: 2012-09-12T13:13:50.000Z
 layout: post
 author: Chad Lung
-title: "Rackspace Open Sources Atom Nuke, The Fast Atom Framework"
+title: 'Rackspace Open Sources Atom Nuke, The Fast Atom Framework'
 categories:
-- Big Data
-- Cloud Servers
+  - Cloud Servers
 ---
 _This story is contributed by [Chad Lung](http://www.linkedin.com/in/chadlung), a software engineer on the Rackspace Cloud Integration team. Chad is the lead maintainer of Atom Hopper project. Be sure to check out his personal blog at [http://www.giantflyingsaucer.com/blog/](http://www.giantflyingsaucer.com/blog/) and follow [@chadlung](https://twitter.com/chadlung) on Twitter._
 

--- a/_posts/2012-09-12-using-your-iphone-to-bootstrap-cloud-servers.markdown
+++ b/_posts/2012-09-12-using-your-iphone-to-bootstrap-cloud-servers.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-09-12 14:00:00
+date: 2012-09-12T14:00:00.000Z
 layout: post
 title: Using your iPhone to bootstrap Cloud Servers
 author: Hart Hoover
 categories:
-- Cloud Servers
+  - Cloud Servers
 ---
 
 With the announcement of the latest [iPhone](http://www.apple.com/iphone/), the tech world is in a frenzy once again. In previous posts, I discussed configuring [Puppet on Cloud Servers](http://devops.rackspace.com/using-puppet-with-cloud-servers.html) and bootstrapping new servers with [libcloud](http://libcloud.apache.org/) and [Puppet](http://puppetlabs.com/puppet/what-is-puppet/). Here, I will go through the process of creating a new server with the Rackspace Cloud iPhone app that automatically bootstraps with Opscode's [Chef](http://opscode.com) or Puppet. With Chef you have the option to use either your own Chef server or Opscode's Hosted Chef platform.

--- a/_posts/2012-09-14-ptr-records.markdown
+++ b/_posts/2012-09-14-ptr-records.markdown
@@ -1,11 +1,10 @@
 ---
 comments: true
-date: 2012-09-14 07:00:36
+date: 2012-09-14T07:00:36.000Z
 layout: post
 author: Mike Sisk
 title: Configuring PTR records using the Rackspace Cloud DNS API
-categories:
-- Cloud DNS
+categories: []
 ---
 
 _This is a guest post by Mike Sisk, a Racker working on DevOps for Rackspace's new cloud products. You can read his blog at [http://mikesisk.com](http://mikesisk.com) or follow _[@msisk](http://twitter.com/msisk)_ on Twitter._

--- a/_posts/2012-09-19-continuous-integration-part-1.markdown
+++ b/_posts/2012-09-19-continuous-integration-part-1.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
-date: 2012-09-19 08:00:00
+date: 2012-09-19T08:00:00.000Z
 layout: post
-title: Continuous integration and Rackspace, part 1
+title: 'Continuous integration and Rackspace, part 1'
 author: Hart Hoover
 categories:
-- Cloud Servers
-- Jenkins
+  - Cloud Servers
+  - Jenkins
 ---
 
 _This is part 1 of a series of using continuous integration with the Rackspace Cloud, specifically with Git and Jenkins. This is not the way Rackspace does continuous integration, but you can use this to get started. Stay tuned for future posts on using Jenkins for _continuous integration_.

--- a/_posts/2012-09-21-supernova-managing-openstack-environments-made-easy.markdown
+++ b/_posts/2012-09-21-supernova-managing-openstack-environments-made-easy.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
-date: 2012-09-21 10:20:53
+date: 2012-09-21T10:20:53.000Z
 layout: post
 title: 'Supernova:  Managing OpenStack Environments Made Easy'
 author: Wayne Walls
 categories:
-- Cloud Servers
-- OpenStack
+  - Cloud Servers
+  - OpenStack
 ---
 
 _[Major Hayden](http://www.linkedin.com/in/majorhayden) first wrote about Supernova in June on his personal [blog](http://rackerhacker.com/?s=supernova). This follow-up post addresses the changes since then, including secondary service provider coverage, new pypi packages and few more usage examples. You can find Major on [Twitter](https://twitter.com/rackerhacker) or hanging out in the #openstack IRC channel on Freenode._

--- a/_posts/2012-09-24-continuous-integration-part-2.markdown
+++ b/_posts/2012-09-24-continuous-integration-part-2.markdown
@@ -1,13 +1,12 @@
 ---
 comments: true
-date: 2012-09-24 09:47:33
+date: 2012-09-24T09:47:33.000Z
 layout: post
-title: Continuous Integration and Rackspace, part 2
+title: 'Continuous Integration and Rackspace, part 2'
 author: Hart Hoover
 categories:
-- Cloud Servers
-- Jenkins
-- Git
+  - Cloud Servers
+  - Jenkins
 ---
 
 _This is part 2 of a series of using continuous integration with the Rackspace Cloud, specifically with Git and Jenkins. This is not the way Rackspace does continuous integration, but you can use this to get started. Stay tuned for future posts on using Jenkins for continuous integration._

--- a/_posts/2012-09-26-openstack-folsom-looking-at-the-numbers.markdown
+++ b/_posts/2012-09-26-openstack-folsom-looking-at-the-numbers.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-09-26 08:00:43
+date: 2012-09-26T08:00:43.000Z
 layout: post
 title: 'OpenStack Folsom: Looking at the numbers'
 author: Hart Hoover
 categories:
-- OpenStack
+  - OpenStack
 ---
 
 [Bitergia](http://bitergia.com) has an excellent [post](http://bitergia.wordpress.com/2012/09/22/preview-of-the-analysis-of-the-upcoming-openstack-release/) on statistics for Folsom, the upcoming release for OpenStack.

--- a/_posts/2012-10-01-mailgun-and-python.markdown
+++ b/_posts/2012-10-01-mailgun-and-python.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
-date: 2012-10-01 16:44:06
+date: 2012-10-01T16:44:06.000Z
 layout: post
 title: Using Mailgun and Python to parse email for your applications
 author: Hart Hoover
 categories:
-- Cloud Servers
-- Mailgun
+  - Cloud Servers
+  - Mailgun
 ---
 
 In case you didn't hear, Rackspace recently [acquired Mailgun](http://techcrunch.com/2012/08/28/rackspace-acquires-y-combinator-startup-mailgun-an-api-that-abstracts-creating-email-inboxes-for-apps-and-web-sites/), a YCombinator startup that makes it really easy to integrate email into your application.  Mailgun does the simple things like sending password confirmations and shipping notifications, but it also makes it A LOT easier to build some really good stuff.

--- a/_posts/2012-10-02-continuous-integration-part-3.markdown
+++ b/_posts/2012-10-02-continuous-integration-part-3.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-02 08:00:41
+date: 2012-10-02T08:00:41.000Z
 layout: post
-title: Continuous Integration and Rackspace, part 3
+title: 'Continuous Integration and Rackspace, part 3'
 author: Jeff Ness
 categories:
-- Cloud Servers
+  - Cloud Servers
 ---
 
 _This is part 3 of a series of using continuous integration with Rackspace. This is a guest post by Jeff Ness, a developer for the Rackspace RPM Development team.

--- a/_posts/2012-10-04-openstack-for-windows.markdown
+++ b/_posts/2012-10-04-openstack-for-windows.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-04 09:00:17
+date: 2012-10-04T09:00:17.000Z
 layout: post
 title: 'OpenStack for Windows Users: So it begins…'
 author: Duan van der Westhuizen
 categories:
-- OpenStack
+  - OpenStack
 ---
 
 _This is a guest post by Duan van der Westhuizen. Duan works at Rackspace in Enterprise Product Development and has been a Racker for almost 6 years. Duan started in our EMEA office where he also had roles in Business Intelligence and Customer Support. He has over 15 years of technology experience across various fields from technology strategy, engineering, development and database design. Duan is a tech at heart who is passionate about leading edge technologies and finding ways to solve market problems through new and innovative solutions._

--- a/_posts/2012-10-09-openstack-for-windows-users-installing-linux.markdown
+++ b/_posts/2012-10-09-openstack-for-windows-users-installing-linux.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-09 08:00:51
+date: 2012-10-09T08:00:51.000Z
 layout: post
 title: 'OpenStack for Windows Users: Installing Linux'
 author: Duan van der Westhuizen
 categories:
-- OpenStack
+  - OpenStack
 ---
 
 _This is a guest post by Duan van der Westhuizen. Duan works at Rackspace in Enterprise Product Development and has been a Racker for almost 6 years. Duan started in our EMEA office where he also had roles in Business Intelligence and Customer Support. He has over 15 years of technology experience across various fields from technology strategy, engineering, development and database design. Duan is a tech at heart who is passionate about leading edge technologies and finding ways to solve market problems through new and innovative solutions._

--- a/_posts/2012-10-09-puppetconf-2012.markdown
+++ b/_posts/2012-10-09-puppetconf-2012.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
-date: 2012-10-09 14:35:59
+date: 2012-10-09T14:35:59.000Z
 layout: post
-title: PuppetConf 2012 videos are live!
+title: 'PuppetConf 2012 videos are live!'
 author: Hart Hoover
 categories:
-- OpenStack
-- Puppet
+  - OpenStack
+  - Puppet
 ---
 
 Puppet Labs just posted all of their videos from PuppetConf 2012 on their [website](http://puppetlabs.com/community/videos/puppetconf/). PuppetConf was held in late September in San Francisco. One of my favorites is this video on deploying OpenStack using Puppet from Robert Starmer, Principal Cloud Engineer at Cisco Systems.

--- a/_posts/2012-10-15-live-from-the-openstack-summit.markdown
+++ b/_posts/2012-10-15-live-from-the-openstack-summit.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-15 11:12:37
+date: 2012-10-15T11:12:37.000Z
 layout: post
 title: Live from the OpenStack Summit
 author: Hart Hoover
 categories:
-- OpenStack
+  - OpenStack
 ---
 
 We are live from the Fall 2012 [OpenStack Summit](http://www.openstack.org/summit/). Follow along as we liveblog the opening keynote!

--- a/_posts/2012-10-15-rackspace-sdks.markdown
+++ b/_posts/2012-10-15-rackspace-sdks.markdown
@@ -1,13 +1,13 @@
 ---
 comments: true
-date: 2012-10-15 14:18:51
+date: 2012-10-15T14:18:51.000Z
 layout: post
 title: Rackspace announces Open Cloud SDKs
 author: Wayne Walls
 categories:
-- Cloud Files
-- Cloud Servers
-- OpenStack
+  - Cloud Files
+  - Cloud Servers
+  - OpenStack
 ---
 
 Since Rackspace's cloud is based, in large part, on the [OpenStack](http://openstack.org) suite of open-source cloud services, each service provides an [application programming interface](http://en.wikipedia.org/wiki/Application_programming_interface) (API) so that these services can be controlled programmatically. To assist developers, Rackspace is providing a set of [software development kits](http://en.wikipedia.org/wiki/Software_development_kit) (SDKs) for working with these APIs in specific programming languages. These SDKs each provide a set of API bindings so that programmers do not have to use the REST API directly. In addition, the SDK's behavior is familiar to the users of that language. Each SDK also provides documentation to help users get started with it, along with tested, working sample code that developers can use for their applications today!

--- a/_posts/2012-10-16-rate-limiting-with-repose-the-restful-proxy-service-engine.markdown
+++ b/_posts/2012-10-16-rate-limiting-with-repose-the-restful-proxy-service-engine.markdown
@@ -1,12 +1,12 @@
 ---
 comments: true
-date: 2012-10-16 13:00:14
+date: 2012-10-16T13:00:14.000Z
 layout: post
-title: Rate Limiting with Repose, the Restful Proxy Service Engine
+title: 'Rate Limiting with Repose, the Restful Proxy Service Engine'
 author: Chad Lung
 categories:
-- General
-- OpenStack
+  - General
+  - OpenStack
 ---
 
 _Chad Lung is a software engineer on the Rackspace Cloud Integration team and is the maintainer of Atom Hopper. Be sure to check out his personal blog at [http://www.giantflyingsaucer.com/blog/](http://www.giantflyingsaucer.com/blog/) and follow [@chadlung](https://twitter.com/chadlung) on Twitter._

--- a/_posts/2012-10-16-video-openstack-summit-day-one.markdown
+++ b/_posts/2012-10-16-video-openstack-summit-day-one.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-16 16:49:33
+date: 2012-10-16T16:49:33.000Z
 layout: post
 title: 'Video: OpenStack Summit Day One'
 author: Hart Hoover
 categories:
-- OpenStack
+  - OpenStack
 ---
 
 This was posted on the [main blog](http://www.rackspace.com/blog/video-openstack-summit-san-diego-day-one/) and features Rackspace Open Cloud Support Systems Engineer Ryan Richard and Content Stacker Anne Gentle. It's a great intro to the Summit and what it's like to be here. Take a look!

--- a/_posts/2012-10-17-video-openstack-summit-day-2.markdown
+++ b/_posts/2012-10-17-video-openstack-summit-day-2.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-17 13:06:59
+date: 2012-10-17T13:06:59.000Z
 layout: post
-author: "Hart Hoover"
+author: Hart Hoover
 title: 'Video: OpenStack Summit Day 2'
 categories:
-- OpenStack
+  - OpenStack
 ---
 
 At OpenStack Summit San Diego this week Rackspace released [a pair of software development kits (SDKs)](http://devops.rackspace.com/rackspace-sdks.html) to make it easier for developers to build applications and accelerate their adoption of the cloud. Here, Everett Toews discusses the SDKs:

--- a/_posts/2012-10-23-cbs-api.markdown
+++ b/_posts/2012-10-23-cbs-api.markdown
@@ -1,11 +1,10 @@
 ---
 comments: true
-date: 2012-10-23 11:05:11
+date: 2012-10-23T11:05:11.000Z
 layout: post
 title: 'Cloud Block Storage: Architecture and API'
 author: Hart Hoover
-categories:
-- Cloud Block Storage
+categories: []
 ---
 
 Today Rackspace [announces the general availability of Cloud Block Storage](http://www.rackspace.com/blog/cloud-block-storage/) which allows you to mount additional storage volumes to your Cloud Servers. In this post we will go through the technical meat of the product including the history of block storage in OpenStack, Cloud Block Storage architecture and API examples.

--- a/_posts/2012-10-30-cn-api.markdown
+++ b/_posts/2012-10-30-cn-api.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-30 15:24:25
+date: 2012-10-30T15:24:25.000Z
 layout: post
 title: 'Cloud Networks: Example Architecture and API'
 author: Hart Hoover
 categories:
-- Cloud Networks
+  - Cloud Networks
 ---
 
 Today’s [launch of Rackspace Cloud Networks](http://www.rackspace.com/blog/cloud-networks-the-next-chapter-in-the-open-cloud/), marks the fourth product release by Rackspace that is powered by an [OpenStack](http://openstack.org) project. When Rackspace founded OpenStack with NASA two years ago the vision was for a community of extremely talented engineers, architects, developers and industry professionals all coming together to build amazing technology. This year alone, Rackspace has launched the following products all powered by OpenStack:

--- a/_posts/2012-10-30-mailgun-capistrano.markdown
+++ b/_posts/2012-10-30-mailgun-capistrano.markdown
@@ -1,11 +1,11 @@
 ---
 comments: true
-date: 2012-10-30 14:07:50
+date: 2012-10-30T14:07:50.000Z
 layout: post
 title: Send emails using Mailgun from your Capistrano recipes
 author: Hart Hoover
 categories:
-- Mailgun
+  - Mailgun
 ---
 
 The guys over at Mailgun just posted an overview of how to use Mailgun to power email notifications from your Capistrano recipes. We've got a lot of customers using Capistrano to automate their big web deployments, so we thought we'd share a summary. You can read the full post on the [Mailgun blog](http://blog.mailgun.com/using-mailgun-with-capistrano-recipes/).

--- a/_posts/2012-11-05-rackspace-is-at-cloud-expo.markdown
+++ b/_posts/2012-11-05-rackspace-is-at-cloud-expo.markdown
@@ -3,7 +3,8 @@ layout: post
 title: "Rackspace is at Cloud Expo!"
 date: 2012-11-05 17:05
 comments: true
-categories: General 
+categories:
+  - General 
 author: "Hart Hoover"
 ---
 Rackspace will be present at [Cloud Expo](http://cloudexpo2012west.sys-con.com/) in Santa Clara this week! If you’re a Rackspace customer we would love for you to stop by our booth and talk to us about how your company uses the [Open Cloud](http://rackspace.com/cloud). We also have several Rackers speaking during the conference:

--- a/_posts/2012-11-05-rackspace-is-at-cloud-expo.markdown
+++ b/_posts/2012-11-05-rackspace-is-at-cloud-expo.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "Rackspace is at Cloud Expo!"
-date: 2012-11-05 17:05
+title: 'Rackspace is at Cloud Expo!'
+date: '2012-11-05 17:05'
 comments: true
 categories:
-  - General 
-author: "Hart Hoover"
+  - General
+author: Hart Hoover
 ---
 Rackspace will be present at [Cloud Expo](http://cloudexpo2012west.sys-con.com/) in Santa Clara this week! If you’re a Rackspace customer we would love for you to stop by our booth and talk to us about how your company uses the [Open Cloud](http://rackspace.com/cloud). We also have several Rackers speaking during the conference:
 

--- a/_posts/2012-11-07-using-the-rackspace-service-registry.markdown
+++ b/_posts/2012-11-07-using-the-rackspace-service-registry.markdown
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "Using the Rackspace Service Registry"
-date: 2012-11-07 22:33
+title: Using the Rackspace Service Registry
+date: '2012-11-07 22:33'
 comments: true
-author: "Hart Hoover"
-categories: [Service Registry]
+author: Hart Hoover
+categories: []
 ---
 {% img featured /rsr_logo.png Rackspace Service Registry %}
 

--- a/_posts/2012-11-25-managing-the-open-cloud-with-windows-8.markdown
+++ b/_posts/2012-11-25-managing-the-open-cloud-with-windows-8.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Managing the Open Cloud with Windows 8"
-date: 2012-11-16 07:00
+title: Managing the Open Cloud with Windows 8
+date: '2012-11-16 07:00'
 comments: true
 author: Phil Jirsa
-categories: 
-- Cloud Servers
-- Microsoft
+categories:
+  - Cloud Servers
 ---
 *Guest post contributed by [Phil Jirsa](http://www.linkedin.com/pub/phil-jirsa/6/746/182), Sharepoint Developer on the Rackspace Sharepoint Services team.  You can follow [Phil on Twitter](https://twitter.com/pjirsa) for more information and Sharepoint goodness.*
 

--- a/_posts/2012-12-06-protect-your-infrastructure-servers-with-bastion-hosts-and-isolated-cloud-networks.markdown
+++ b/_posts/2012-12-06-protect-your-infrastructure-servers-with-bastion-hosts-and-isolated-cloud-networks.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "Protect your Infrastructure Servers with Bastion Hosts and Isolated Cloud Networks"
-date: 2012-11-27 09:13
+title: Protect your Infrastructure Servers with Bastion Hosts and Isolated Cloud Networks
+date: '2012-11-27 09:13'
 comments: true
 author: Brandon Philips
 categories:
-- Cloud Networks
+  - Cloud Networks
 ---
 *This guest post was contributed by [Mr. Brandon Philips](http://www.linkedin.com/in/brandonphilips). Brandon is part of a small team of Rackers getting the Rackspace Cloud Monitoring Agent ready for launch. The Agent will help customers monitor the internals of their servers and application. You can check out his site at <http://ifup.org>, find him at local San Francisco meetups and check out his code on [Github](https://github.com/philips).*
 

--- a/_posts/2012-12-06-the-new-devops-blog.markdown
+++ b/_posts/2012-12-06-the-new-devops-blog.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "The New DevOps Blog"
-date: 2012-12-06 12:07
+title: The New DevOps Blog
+date: '2012-12-06 12:07'
 comments: true
 author: Hart Hoover
 categories:
-- General
+  - General
 ---
 We've moved! The Rackspace DevOps Blog is now hosted on Rackspace [Cloud Files](http://www.rackspace.com/cloud/public/files/) (powered by [OpenStack Swift](http://www.openstack.org/software/openstack-storage/)) using [Octopress](http://octopress.org/). This blog was hosted on [WordPress](http://www.wordpress.org), using a mix of various Rackspace Open Cloud products:
 

--- a/_posts/2012-12-07-the-rackspace-cloud-sdk-for-java.markdown
+++ b/_posts/2012-12-07-the-rackspace-cloud-sdk-for-java.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "The Rackspace Cloud SDK for Java"
-date: 2012-12-10 08:00
+title: The Rackspace Cloud SDK for Java
+date: '2012-12-10 08:00'
 comments: true
 author: Everett Toews
 published: true
-categories: 
-- SDK
-- Java
+categories:
+  - SDK
+  - Java
 ---
 At the OpenStack Grizzly Summit in October 2012, Rackspace announced our Java Software Development Kit (SDK) for the open cloud. The Java SDK is powered by jclouds, an open source library that helps you get started in the cloud and employ your Java development skills. The jclouds Application Programming Interface (API) gives you the freedom to write portable code that works with many cloud providers or write code that utilizes cloud specific features. It also works with both public and private clouds, enabling hybrid cloud workloads.
 <!-- more -->

--- a/_posts/2012-12-11-how-the-cloud-monitoring-team-implemented-mailgun-to-automate-monitoring-alerts.markdown
+++ b/_posts/2012-12-11-how-the-cloud-monitoring-team-implemented-mailgun-to-automate-monitoring-alerts.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "How the Cloud Monitoring team implemented Mailgun to automate monitoring alerts"
-date: 2012-12-11 11:52
+title: How the Cloud Monitoring team implemented Mailgun to automate monitoring alerts
+date: '2012-12-11 11:52'
 comments: true
 author: Wayne A. Walls
-categories: 
-- Mailgun
-- Cloud Monitoring
+categories:
+  - Mailgun
+  - Cloud Monitoring
 ---
 The team over at Mailgun just posted a [case study](http://blog.mailgun.com/how-node-js-app-cloud-monitoring-uses-the-mailgun-api/) about how the Rackspace Cloud Monitoring team successfully migrated their email alerts to the [Mailgun email automation platform](http://www.mailgun.com/). It's a really interesting read that is as much about how to plan for and deploy 3rd party tools in a production application as it is about using Mailgun to automate and monitor email alerts.
 <!-- more -->

--- a/_posts/2012-12-18-getting-bureaucratic-with-papertrail.markdown
+++ b/_posts/2012-12-18-getting-bureaucratic-with-papertrail.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Getting Bureaucratic with Papertrail"
-date: 2012-12-21 09:05
+title: Getting Bureaucratic with Papertrail
+date: '2012-12-21 09:05'
 comments: true
 author: Hart Hoover
-categories: 
-- Cloud Servers
-- Cloud Tools
+categories:
+  - Cloud Servers
 ---
 Imagine the situation: you're a Racker, and a customer calls. Their servers are up, but their application or site is offline. Time to shine! Unfortunately, they don't have any idea what is going on and they are frantic. The account has 20 servers listed and they are named after the characters in [The Hobbit](http://en.wikipedia.org/wiki/Characters_in_The_Hobbit).
 

--- a/_posts/2013-01-02-2013-resolutions.markdown
+++ b/_posts/2013-01-02-2013-resolutions.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "2013: An Open Cloud Resolution"
-date: 2013-01-02 09:19
+title: '2013: An Open Cloud Resolution'
+date: '2013-01-02 09:19'
 comments: true
 author: Hart Hoover
-categories: 
-- OpenStack
+categories:
+  - OpenStack
 ---
 It's a new year, and that means that many people are making resolutions to better themselves. Some make resolutions to read more books. Some make resolutions to exercise. Some people have more, um, interesting resolutions:
 

--- a/_posts/2013-01-09-cooking-with-chef.markdown
+++ b/_posts/2013-01-09-cooking-with-chef.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Cooking with Chef, part 1"
-date: 2013-01-11 08:00
+title: 'Cooking with Chef, part 1'
+date: '2013-01-11 08:00'
 comments: true
 author: Hart Hoover
-categories: 
-- Cloud Servers
-- Chef
-- Configuration Management
+categories:
+  - Cloud Servers
+  - Chef
+  - Configuration Management
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png "Chef Logo" %}
 

--- a/_posts/2013-01-09-how-imgpage-uploads-25-mb-photos-to-cloud-files-using-the-mailgun-api.markdown
+++ b/_posts/2013-01-09-how-imgpage-uploads-25-mb-photos-to-cloud-files-using-the-mailgun-api.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "How ImgPage uploads 25 MB photos to Cloud Files using the Mailgun API"
-date: 2013-01-09 15:41
+title: "How ImgPage uploads 25\_MB photos to Cloud Files using the Mailgun API"
+date: '2013-01-09 15:41'
 comments: true
 author: Paul Finn
-categories: 
-- Mailgun
-- Python
+categories:
+  - Mailgun
+  - Python
 ---
 *The team over at Mailgun just posted a Python tutorial written by Mailgun customer [Paul Finn](http://twitter.com/@paul_finn_) about how to use Python and the Mailgun API to upload large images to Cloud Files.  The use case for the post is uploading photos from your phone, but the same process could be used anytime to want to parse an email attachment and store it in the cloud.  You can check out the [full Mailgun and python tutorial](http://blog.mailgun.com/python-tutorial-how-imgpage-lets-you-upload-25-mb/) at the Mailgun blog, but we have the highlights here. --Hart*
 <!-- more -->

--- a/_posts/2013-01-10-cooking-with-chef2.markdown
+++ b/_posts/2013-01-10-cooking-with-chef2.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Cooking with Chef, part 2"
-date: 2013-01-16 08:00
+title: 'Cooking with Chef, part 2'
+date: '2013-01-16 08:00'
 comments: true
 author: Hart Hoover
-categories: 
-- Cloud Servers
-- Chef
-- Configuration Management
+categories:
+  - Cloud Servers
+  - Chef
+  - Configuration Management
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png "Chef Logo" %}
 

--- a/_posts/2013-02-05-rackspace-and-appfog-partner-at-apps-world.markdown
+++ b/_posts/2013-02-05-rackspace-and-appfog-partner-at-apps-world.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "Rackspace &amp; AppFog Partner at Apps World"
-date: 2013-02-05 09:21
+title: 'Rackspace &amp; AppFog Partner at Apps World'
+date: '2013-02-05 09:21'
 comments: true
 author: Hart Hoover
-categories: 
-- General
+categories:
+  - General
 ---
 [Rackspace](http://www.rackspace.com) and [AppFog](http://appfog.com) are throwing a Happy Hour on Thursday, February 7 at AppsWorld in San Francisco, and we’re asking developers to create an app that helps us choose the beers that will be served at the party. You could win an iPad! All you need to do is [RSVP](http://www.cvent.com/events/rackspace-appfog-happy-hour/event-summary-07b1437cd7ba4459819e587870b0f854.aspx) to the party, [register for the contest](http://get.appfog.com/appsandbeers), and then create an app (deployed on AppFog and Rackspace) that allows people to vote for which beers will be served at the happy hour. 
 

--- a/_posts/2013-02-10-host-your-facebook-app-on-the-rackspace-open-cloud.markdown
+++ b/_posts/2013-02-10-host-your-facebook-app-on-the-rackspace-open-cloud.markdown
@@ -1,16 +1,15 @@
 ---
 layout: post
-title: "Host Your Facebook App On The Rackspace Open Cloud"
-date: 2013-02-10 22:20
+title: Host Your Facebook App On The Rackspace Open Cloud
+date: '2013-02-10 22:20'
 comments: true
 published: true
 author: Garry Prior
-categories: 
-- Cloud Servers
-- Cloud Networks
-- Cloud Monitoring
-- Cloud Files
-- Cloud Databases
+categories:
+  - Cloud Servers
+  - Cloud Networks
+  - Cloud Monitoring
+  - Cloud Files
 ---
 We live our lives on the web. And [social media and networking has established itself a dominant force](http://blog.nielsen.com/nielsenwire/social/2012/), becoming the most visited sites on the web – and among the most popular social media sites, [Facebook has become the colossus](http://www.internetworldstats.com/facebook.htm), amassing more than an estimated 930 million users.
 

--- a/_posts/2013-02-15-cooking-with-chef-part-3.markdown
+++ b/_posts/2013-02-15-cooking-with-chef-part-3.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Cooking with Chef, part 3"
-date: 2013-02-15 08:00
+title: 'Cooking with Chef, part 3'
+date: '2013-02-15 08:00'
 comments: true
 author: Hart Hoover
-categories: 
-- Cloud Servers
-- Chef
-- Configuration Management
+categories:
+  - Cloud Servers
+  - Chef
+  - Configuration Management
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png "Chef Logo" %}
 

--- a/_posts/2013-02-15-using-pyrax-to-deploy.markdown
+++ b/_posts/2013-02-15-using-pyrax-to-deploy.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Using pyrax to deploy the DevOps Blog"
-date: 2013-02-15 13:17
+title: Using pyrax to deploy the DevOps Blog
+date: '2013-02-15 13:17'
 comments: true
 author: Justin Phelps
-categories: 
-- Cloud Files
-- Python
-- pyrax
+categories:
+  - Cloud Files
+  - Python
 ---
 _This is a guest post written by Justin Phelps, a Rackspace Cloud support Racker. You can follow him on [LinkedIn](http://www.linkedin.com/in/linuturk), [@Linuturk](http://twitter.com/linuturk) on twitter, or find him on [Google+](https://plus.google.com/112828903529889228389/posts)_
 

--- a/_posts/2013-02-18-python-magic-and-remote-apis.markdown
+++ b/_posts/2013-02-18-python-magic-and-remote-apis.markdown
@@ -4,9 +4,9 @@ title: "Python magic and remote APIs"
 date: 2013-02-18 08:00
 comments: true
 author: Jesse Keating
-categories: 
+categories:
 - Python
-- Developer
+- Developers
 ---
 _This is a guest post by Jesse Keating, a Racker working on DevOps for Rackspace's Cloud Server products. You can read his blog at [http://raxcloud.blogspot.com/](http://raxcloud.blogspot.com) or follow _[@iamjkeating](http://twitter.com/iamjkeating)_ on Twitter._
 
@@ -69,7 +69,7 @@ then be used in later functions, like a login or query function.
             self.SessURL = self.API + 'session/'
             self.QAPI = self.API + 'query/'
             self._session = None
-        
+
         def _login(self):
             username = myuser
             password = mypass
@@ -77,7 +77,7 @@ then be used in later functions, like a login or query function.
             data = {'password': password}
             r = requests.get('%sauth/%s' % (self.API, username), params=data)
             return r.json()
-            
+
         @property
         def session(self):
             if not self._session:
@@ -124,7 +124,7 @@ With this structure we can do things like:
 ```python
     cserv = CServ()
     cserv.query('Computer.Computer', 432807, attributes=['name'])
-      [{u'count': 1, u'load_arg': 432807, u'limit': 1, u'result': 
+      [{u'count': 1, u'load_arg': 432807, u'limit': 1, u'result':
 
       [{u'name': u'silly.hostname.here.com'}], u'offset': 0,
 
@@ -213,7 +213,7 @@ now in the base class, lets create a Computer class.
             self.number = number
             self._qval = self.number
 
-            super(Computer, self).__init__() 
+            super(Computer, self).__init__()
 ```
 
 That's all there is to it.  `_qclass` is defined as a class attribute, it

--- a/_posts/2013-02-18-python-magic-and-remote-apis.markdown
+++ b/_posts/2013-02-18-python-magic-and-remote-apis.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Python magic and remote APIs"
-date: 2013-02-18 08:00
+title: Python magic and remote APIs
+date: '2013-02-18 08:00'
 comments: true
 author: Jesse Keating
 categories:
-- Python
-- Developers
+  - Python
+  - Developers
 ---
 _This is a guest post by Jesse Keating, a Racker working on DevOps for Rackspace's Cloud Server products. You can read his blog at [http://raxcloud.blogspot.com/](http://raxcloud.blogspot.com) or follow _[@iamjkeating](http://twitter.com/iamjkeating)_ on Twitter._
 

--- a/_posts/2013-02-19-apache-hadoop-on-rackspace-private-cloud.markdown
+++ b/_posts/2013-02-19-apache-hadoop-on-rackspace-private-cloud.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Apache Hadoop on Rackspace Private Cloud"
-date: 2013-02-19 08:00
+title: Apache Hadoop on Rackspace Private Cloud
+date: '2013-02-19 08:00'
 comments: true
 author: Sudarshan Acharya
 categories:
-- Private Cloud
-- OpenStack
-- Big Data
-- hadoop
+  - Private Cloud
+  - OpenStack
 ---
 I truly believe that in the next five years, cloud will be the default way that IT resources like compute and storage will be consumed. As a provider of [public](http://www.rackspace.com/cloud/) and [private](http://www.rackspace.com/cloud/private/) clouds powered by OpenStack, we at Rackspace are committed to making OpenStack the preferred infrastructure layer for a lot of platforms and applications.
 <!-- more -->

--- a/_posts/2013-02-20-come-see-us-at-scale-11x.markdown
+++ b/_posts/2013-02-20-come-see-us-at-scale-11x.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Come see us at SCALE 11x"
-date: 2013-02-20 14:32
+title: Come see us at SCALE 11x
+date: '2013-02-20 14:32'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- General
+categories:
+  - General
 ---
 Rackspace will be at the [11th Annual Southern California Linux Expo](http://www.socallinuxexpo.org/scale11x/)! SCALE 11X takes place on Feb. 22-24, 2013, at the Hilton Los Angeles Airport hotel. As the first-of-the-year Linux/Open Source software expo in North America, SCALE 11X expects to host more than 100 exhibitors this year, along with presenting more than 70 speakers.
 <!-- more -->

--- a/_posts/2013-02-21-service-registry-use-cases-storing-service-metadata-in-the-registry.markdown
+++ b/_posts/2013-02-21-service-registry-use-cases-storing-service-metadata-in-the-registry.markdown
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Service Registry Use Cases: Storing Service Metadata In The Registry"
-date: 2013-02-21 08:04
+title: 'Service Registry Use Cases: Storing Service Metadata In The Registry'
+date: '2013-02-21 08:04'
 comments: true
 author: Tomaz Muraus
-categories: 
-- Service Registry
+categories: []
 ---
 _This is a guest post from Tomaz Muraus. Tomaz is a Racker and a project lead for the Rackspace Service Registry product. He is also a project chair of [Apache Libcloud](http://libcloud.apache.org/), an open-source project which deals with cloud interoperability. Before working on Service Registry he worked on the [Cloud Monitoring](http://www.rackspace.com/cloud/monitoring/) product and before joining Rackspace, he worked at [Cloudkick](https://www.cloudkick.com/) helping customers manage and monitor their infrastructure. In his free time, he loves writting code, contributing to open-source projects, advocating for software freedom, going to the gym and cycling. Be sure to check out his GitHub [page](https://github.com/Kami)._
 

--- a/_posts/2013-02-22-deploying-rackspace-private-cloud-software-on-bare-metal.markdown
+++ b/_posts/2013-02-22-deploying-rackspace-private-cloud-software-on-bare-metal.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Deploying Rackspace Private Cloud Software On Bare Metal"
-date: 2013-02-22 08:00
+title: Deploying Rackspace Private Cloud Software On Bare Metal
+date: '2013-02-22 08:00'
 comments: true
 author: Egle Sigler
-categories: 
-- Private Cloud
-- OpenStack
-- Chef
+categories:
+  - Private Cloud
+  - OpenStack
+  - Chef
 ---
 _Egle Sigler is a Private Cloud Architect, who started working at Rackspace in 2008. She was one of the first to receive Rackspace OpenStack certification. Before working with OpenStack, Egle worked on MyRackspace customer control panel, software architecture and enterprise tools. In her spare time, Egle enjoys traveling, hiking, snorkeling and nature photography._
 

--- a/_posts/2013-02-25-cooking-with-chef4.markdown
+++ b/_posts/2013-02-25-cooking-with-chef4.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "How Rackspace uses Chef to deploy OpenStack in the Private Cloud"
-date: 2013-02-25 08:00
+title: How Rackspace uses Chef to deploy OpenStack in the Private Cloud
+date: '2013-02-25 08:00'
 comments: true
 author: Ryan Richard
-categories: 
-- OpenStack
-- Chef
-- Private Cloud
+categories:
+  - OpenStack
+  - Chef
+  - Private Cloud
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png "Chef Logo" %}
 

--- a/_posts/2013-02-27-benchmarking-hosted-mongodb-services.markdown
+++ b/_posts/2013-02-27-benchmarking-hosted-mongodb-services.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Benchmarking hosted MongoDB services"
-date: 2013-02-27 09:00
+title: Benchmarking hosted MongoDB services
+date: '2013-02-27 09:00'
 comments: true
 author: Paul Querna
 published: true
-categories:
-- Cloud Databases
-- ObjectRocket
-- mongodb
+categories: []
 ---
 
 When we started investigating the hosted MongoDB space, we quickly found that most of the companies involved were just hosting MongoDB on top of AWS instances. We were intrigued by the different approach taken by ObjectRocket.  Instead of using AWS primitives, they built their service on their own hardware in neighboring data centers, and utilized AWS DirectConnect to provide low latency connectivity.

--- a/_posts/2013-02-28-built-for-developers-rackspace-open-cloud-community.markdown
+++ b/_posts/2013-02-28-built-for-developers-rackspace-open-cloud-community.markdown
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Built for Developers: Rackspace Open Cloud Community"
-date: 2013-02-28 12:14
+title: 'Built for Developers: Rackspace Open Cloud Community'
+date: '2013-02-28 12:14'
 comments: true
-author: Kev Bittner  
-categories: 
-- Community
+author: Kev Bittner
+categories: []
 ---
 _Kev Bittner has been a Racker since 2010 and is the Developer Community Manager for the Rackspace Open Cloud Community. Previously, he was the Product Design Lead for storage products and a UI Designer for the Cloud Control Panel. Before joining Rackspace, Kev worked as lead developer and IT manager in advertising and education. When he’s not writing code or designing sites, Kev keeps the systems running and DJs for K-RACK, Rackspace’s internal radio station. Follow him on Twitter at [@rackerkev](http://twitter.com/rackerkev)._
 

--- a/_posts/2013-03-01-crank-up-app-security-with-multi-factor-authentication.markdown
+++ b/_posts/2013-03-01-crank-up-app-security-with-multi-factor-authentication.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Crank Up App Security With Multi-Factor Authentication"
-date: 2013-03-01 06:59
+title: Crank Up App Security With Multi-Factor Authentication
+date: '2013-03-01 06:59'
 comments: true
 author: Major Hayden
-categories: 
-- Security
-- Authentication
+categories:
+  - Security
 ---
 {% img right 2013-03-01-crank-up-app-security/lockkey.png %}
 

--- a/_posts/2013-03-04-how-i-learned-ruby-on-rails.markdown
+++ b/_posts/2013-03-04-how-i-learned-ruby-on-rails.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "How I Learned Ruby On Rails"
-date: 2013-03-04 07:45
+title: How I Learned Ruby On Rails
+date: '2013-03-04 07:45'
 comments: true
 author: Bret McGowen
-categories: 
-- Ruby
-- SDK
-- Fog
+categories:
+  - Ruby
+  - SDK
 ---
 _Bret McGowen is a software developer at Rackspace, designing and building [RackConnect](http://www.rackspace.com/cloud/hybrid/dedicated_cloud/rackconnect/), which lets customers have the best of both traditional and cloud hosting._
 

--- a/_posts/2013-03-06-clustered-storage-on-rackspace-opencloud.markdown
+++ b/_posts/2013-03-06-clustered-storage-on-rackspace-opencloud.markdown
@@ -1,16 +1,12 @@
 ---
 layout: post
-title: "Clustered Storage on Rackspace Open Cloud using Cloud Networks and Cloud Block Storage"
-date: 2013-03-06 12:00
+title: Clustered Storage on Rackspace Open Cloud using Cloud Networks and Cloud Block Storage
+date: '2013-03-06 12:00'
 comments: true
 author: Niko Gonzales
-categories: 
-- OpenStack
-- DRBD
-- GlusterFS
-- GFS2
-- Cloud Block Storage
-- Cloud Networks
+categories:
+  - OpenStack
+  - Cloud Networks
 ---
 Rackspace has rolled out quite a few new products in the past 6 months - most notable among them are Cloud Block Storage and Cloud Networks. These technologies provide the power and flexibility that was previously non-existent in Rackspace Cloud. Administrators are now able to have private networks, attach and detach custom-sized storage volumes to their servers, and much more. In this post we'll talk about using Cloud Networks and Cloud Block Storage to build scalable, resilient application environments.
 <!-- more -->

--- a/_posts/2013-03-06-rackspace-private-cloud-digging-deeper-into-opencenter.markdown
+++ b/_posts/2013-03-06-rackspace-private-cloud-digging-deeper-into-opencenter.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Rackspace Private Cloud - Digging Deeper into OpenCenter, High Availability"
-date: 2013-03-06 07:00
+title: 'Rackspace Private Cloud - Digging Deeper into OpenCenter, High Availability'
+date: '2013-03-06 07:00'
 comments: true
 author: Kevin Jackson
-categories: 
-- Private Cloud
-- OpenStack
+categories:
+  - Private Cloud
+  - OpenStack
 ---
 Today we unveiled some key updates to [Rackspace Private Cloud](https://www.rackspace.com/cloud/private/), which improve the platform's capabilities. Here, we'll drill into some of the architecture and technology behind this latest update and focus on two key features: High Availability of OpenStack components including MySQL and RabbitMQ; and OpenCenter, the open source Rackspace Private Cloud management API and graphical user interface that includes a powerful command line to allow administrators to harness even more control over their environments.<!-- more -->
 

--- a/_posts/2013-03-07-rackspace-at-sxsw.markdown
+++ b/_posts/2013-03-07-rackspace-at-sxsw.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Rackspace at SXSW"
-date: 2013-03-07 08:00
+title: Rackspace at SXSW
+date: '2013-03-07 08:00'
 comments: true
 author: Hart Hoover
-categories: 
-- Events
-- SXSW
+categories:
+  - Events
 ---
 Rackspace is bringing the Open Cloud Experience to the SXSW Interactive Festival! Come join us over the next few days and learn all about the Open Cloud. We’ll be headquartered at [Champions Sports Bar & Restaurant](http://www.championsaustin.com/) at the [Courtyard Marriott](http://goo.gl/maps/YiQT4), so be sure to stop in and see us.<!-- more -->
 

--- a/_posts/2013-03-13-transitioning-to-littlechef.markdown
+++ b/_posts/2013-03-13-transitioning-to-littlechef.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Transitioning to LittleChef"
-date: 2013-03-13
+title: Transitioning to LittleChef
+date: 2013-03-13T00:00:00.000Z
 comments: true
 author: Dave King
 categories:
-- Chef
-- Ruby
-- Configuration Management
+  - Chef
+  - Ruby
+  - Configuration Management
 ---
 I was once debugging a deployment issue where one server wouldn't send outgoing email, even though it was running the same version of our application software as other machines that were functioning just fine.  After a while I traced it down to the fact that four years ago a developer had stuck an extra mail JAR file into the Tomcat `lib/` directory.  This incident showed me that every server performing a function should be _exactly the same_ as every other server performing that function.<!-- more -->
 

--- a/_posts/2013-03-14-security-on-the-open-cloud.markdown
+++ b/_posts/2013-03-14-security-on-the-open-cloud.markdown
@@ -4,9 +4,9 @@ title: "Security on the Open Cloud"
 date: 2013-03-14 08:00
 comments: true
 author: Hart Hoover
-categories: 
-- Security
-- Five Pillars
+categories:
+  - Security
+  - Five Pillars
 ---
 {% img right pillars/pillar.png 160 160 %}
 Security is a major concern for all hosting platforms, but in the cloud security has traditionally been a detractor to cloud adoption. Security concerns include:

--- a/_posts/2013-03-14-security-on-the-open-cloud.markdown
+++ b/_posts/2013-03-14-security-on-the-open-cloud.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Security on the Open Cloud"
-date: 2013-03-14 08:00
+title: Security on the Open Cloud
+date: '2013-03-14 08:00'
 comments: true
 author: Hart Hoover
 categories:
   - Security
-  - Five Pillars
 ---
 {% img right pillars/pillar.png 160 160 %}
 Security is a major concern for all hosting platforms, but in the cloud security has traditionally been a detractor to cloud adoption. Security concerns include:

--- a/_posts/2013-03-14-vagrant-now-supports-rackspace-open-cloud.markdown
+++ b/_posts/2013-03-14-vagrant-now-supports-rackspace-open-cloud.markdown
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Vagrant now supports Rackspace Open Cloud"
-date: 2013-03-14  08:00
+title: Vagrant now supports Rackspace Open Cloud
+date: '2013-03-14  08:00'
 comments: true
 author: Tomaz Muraus
-categories:
-- Vagrant
+categories: []
 ---
 We are happy to announce support for Rackspace Open Cloud in [Vagrant 1.1](http://www.vagrantup.com/)!
 

--- a/_posts/2013-03-15-introducing-project-meniscus-the-python-event-cloud-logging-service.markdown
+++ b/_posts/2013-03-15-introducing-project-meniscus-the-python-event-cloud-logging-service.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Introducing Project Meniscus: The Python Event Cloud Logging Service"
-date: 2013-03-26 08:00
+title: 'Introducing Project Meniscus: The Python Event Cloud Logging Service'
+date: '2013-03-26 08:00'
 comments: true
 author: Chad Lung
 categories:
-- OpenStack
-- Python
+  - OpenStack
+  - Python
 ---
 
 **Dream big:** that is our vision on the Rackspace [Project Meniscus](http://projectmeniscus.org) team. In one of our dreams, we

--- a/_posts/2013-03-17-determining-optimal-storage-based-on-iops.markdown
+++ b/_posts/2013-03-17-determining-optimal-storage-based-on-iops.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Determining Optimal Storage based on IOPS"
-date: 2013-03-18 8:00
+title: Determining Optimal Storage based on IOPS
+date: '2013-03-18 8:00'
 comments: true
 author: Edward Adame
-categories: 
-- Cloud Servers
-- Cloud Block Storage
+categories:
+  - Cloud Servers
 ---
 Rackspace Cloud Servers come in various sizes, and larger Cloud Servers are allocated a greater portion of available hypervisor resources. As of today, our largest Cloud Server (30 GB RAM / 1.2 TB disk space) consumes the entire physical hypervisor. A 15 GB Cloud Server consumes half of the hypervisor’s resources, an 8 GB server consumes a quarter, and so on until you get to the smallest allocation we provide (512 MB / 20 GB disk space).
 

--- a/_posts/2013-03-20-using-a-custom-kernel-with-cloud-servers.markdown
+++ b/_posts/2013-03-20-using-a-custom-kernel-with-cloud-servers.markdown
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "Using a custom kernel with the Ubuntu Installer"
-date: 2013-03-20 8:00
+title: Using a custom kernel with the Ubuntu Installer
+date: '2013-03-20 8:00'
 comments: true
-author: Jordan Evans 
-categories: 
-- Cloud Servers
+author: Jordan Evans
+categories:
+  - Cloud Servers
 ---
 EDIT: This blog post has been edited! As it turns out, the preseed was stored in a location that didn't always work. Instead, we now decompress the initrd.gz, and add a preseed there. This is a better location, because the Ubuntu installer always looks for it there, even if not told to. We also moved installing the new kernel to the end of the preseed, to be sure it runs all the postinstall scripts. We changed how we remove the 2.6 kernel to specifically catch the version before removing it.
 

--- a/_posts/2013-03-21-agility-in-the-rackspace-open-cloud.markdown
+++ b/_posts/2013-03-21-agility-in-the-rackspace-open-cloud.markdown
@@ -1,12 +1,10 @@
 ---
 layout: post
-title: "Agility in the Rackspace Open Cloud"
-date: 2013-03-21 8:00
+title: Agility in the Rackspace Open Cloud
+date: '2013-03-21 8:00'
 comments: true
 author: Hart Hoover
-categories: 
-- Five Pillars
-- Agile
+categories: []
 ---
 {% img right pillars/pillar.png 160 160 %}
 Being able to roll with the punches in a cloud environment is extremely important. The cloud can be used for a steady state environment, but really shines when coupled with monitoring and the API. Every application in the cloud should fit in one of these four buckets:

--- a/_posts/2013-03-25-rackspace-cloud-backup-api-with-curl.markdown
+++ b/_posts/2013-03-25-rackspace-cloud-backup-api-with-curl.markdown
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Rackspace Cloud Backup API with cURL"
-date: 2013-04-01 08:00
+title: Rackspace Cloud Backup API with cURL
+date: '2013-04-01 08:00'
 comments: true
 author: Oz Akan
-categories: 
-- Cloud Backup
+categories: []
 ---
 
 > **WARNING:** this blog post contains information that is not up to date. Consult [this](http://docs.rackspace.com/rcbu/api/v1.0/rcbu-getting-started/content/createWorkWithBackups-d1e01.html) guide for authoritative and up to date information.

--- a/_posts/2013-03-26-scaling-horizontally-handling-sessions-on-the-open-cloud.markdown
+++ b/_posts/2013-03-26-scaling-horizontally-handling-sessions-on-the-open-cloud.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Scaling Horizontally: Handling Sessions on the Open Cloud"
-date: 2013-03-28 12:00
+title: 'Scaling Horizontally: Handling Sessions on the Open Cloud'
+date: '2013-03-28 12:00'
 comments: true
 published: true
 author: Hart Hoover
 categories:
-- Five Pillars
-- Cloud Servers
-- REST
+  - Cloud Servers
 ---
 {% img right pillars/pillar.png 160 160 %}
 Wayne Walls wrote a great article on the Rackspace Blog around [horizontal scaling](http://www.rackspace.com/blog/pillars-of-cloudiness-no-3-scaling-horizontally/), a pillar of cloud application design. When designing applications in the cloud, typically you need more than one server performing specific tasks.

--- a/_posts/2013-03-27-rackspace-service-registry-status-update-performance-and-reliability-improvements-new-features-and-more.markdown
+++ b/_posts/2013-03-27-rackspace-service-registry-status-update-performance-and-reliability-improvements-new-features-and-more.markdown
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Rackspace Service Registry Status Update - Performance and Reliability Improvements, New Features and More"
-date: 2013-03-27 08:00
+title: 'Rackspace Service Registry Status Update - Performance and Reliability Improvements, New Features and More'
+date: '2013-03-27 08:00'
 comments: true
 author: Tomaz Muraus
-categories:
-- Service Registry
+categories: []
 ---
 Back in November we announced the [Rackspace Service Registry preview](http://www.rackspace.com/blog/keep-track-of-your-services-and-applications-with-the-new-rackspace-service-registry/).
 Since then we have been busy listening to user feedback, using that data along

--- a/_posts/2013-03-28-using-airbrake-on-the-rackspace-cloud.markdown
+++ b/_posts/2013-03-28-using-airbrake-on-the-rackspace-cloud.markdown
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Using Airbrake on the Rackspace Cloud"
-date: 2013-03-28 08:15
+title: Using Airbrake on the Rackspace Cloud
+date: '2013-03-28 08:15'
 comments: true
 author: Ben Arent
-categories: 
-- Airbrake
+categories: []
 ---
 For a developer, the DevOps journey can be full of surprises. For example, server automation for setup lets developers have full control to fine tune and tweak applications for maximum performance; but once the server and app are up, the quest for a high quality application continues. 
 

--- a/_posts/2013-04-01-speeding-up-ssh-session-creation.markdown
+++ b/_posts/2013-04-01-speeding-up-ssh-session-creation.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Speeding up SSH Session Creation"
-date: 2013-04-03 08:00
+title: Speeding up SSH Session Creation
+date: '2013-04-03 08:00'
 comments: true
 author: Greg Brockman
 published: true
-categories: 
-- Cloud Servers
+categories:
+  - Cloud Servers
 ---
 Establishing a new SSH connection usually takes only a few seconds, but if you're connecting to a server multiple times in succession the overhead starts to add up. If you do a lot of Git pushing and pulling or frequently need to SSH to a dev server, you've probably felt the pain of waiting for SSH to connect so you can get back to doing work.
 

--- a/_posts/2013-04-03-modular-application-design.markdown
+++ b/_posts/2013-04-03-modular-application-design.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Modular Application Design with Services"
-date: 2013-04-04 08:00
+title: Modular Application Design with Services
+date: '2013-04-04 08:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Cloud Servers
-- Five Pillars
-- Cloud Tools
+categories:
+  - Cloud Servers
 ---
 {% img right pillars/pillar.png 160 160 %}
 

--- a/_posts/2013-04-09-announcing-the-objective-c-mailgun-sdk.markdown
+++ b/_posts/2013-04-09-announcing-the-objective-c-mailgun-sdk.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Announcing the Objective-C Mailgun SDK"
-date: 2013-04-09 12:26
+title: Announcing the Objective-C Mailgun SDK
+date: '2013-04-09 12:26'
 comments: true
 author: Jay Baird
 published: true
-categories: 
-- Mailgun
+categories:
+  - Mailgun
 ---
 One of my favorite services here at Rackspace is [Mailgun](http://mailgun.com), a set of APIs that allow you to send email and manage mailing lists via a REST API. Coming back from a recent trip to San Antonio I decided that I would add an Objective-C interface to send email via Mailgun using my own iOS interface instead of using Apple's `MFMailComposeViewController`. This library is now [open sourced on Github](https://github.com/rackerlabs/objc-mailgun) and available via [Cocoapods](http://cocoapods.org).<!-- more -->
 

--- a/_posts/2013-04-09-is-mysql-unknowingly-replicating-your-failure-as-a-dba.markdown
+++ b/_posts/2013-04-09-is-mysql-unknowingly-replicating-your-failure-as-a-dba.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Are you unknowingly replicating your failure as a DBA?"
-date: 2013-04-09 08:00
+title: Are you unknowingly replicating your failure as a DBA?
+date: '2013-04-09 08:00'
 comments: true
 author: Steve Katen
 published: true
 categories:
-- Cloud Servers
-- Cloud Monitoring
-- Managed Cloud
-- mysql
+  - Cloud Servers
+  - Cloud Monitoring
 ---
 MySQL replication offers an opportunity to distribute your database to multiple nodes for additional performance or to off-load specific functionality from your production stack. When uptime is a requirement, table-locking can create unavailability and a long-running nightly backup can cause an unexpected outage. One benefit of replication is that it allows the backup to happen on the slave without interrupting your production environment. So what happens  when you rely on this configuration to safeguard your data without constantly ensuring that the replication process is working? I'll tell you what happens – you're the guy without a recent backup.<!-- more -->  
 

--- a/_posts/2013-04-09-service-registry-curator-bindings.markdown
+++ b/_posts/2013-04-09-service-registry-curator-bindings.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Service Registry Bindings for Netflix Curator"
-date: 2013-04-10 08:00
+title: Service Registry Bindings for Netflix Curator
+date: '2013-04-10 08:00'
 comments: true
 author: Gary Dusbabek
 published: true
-categories: 
-- Service Registry
+categories: []
 ---
 ##The Problem
 Have you ever set out to do something new, only to find yourself encumbered by a list of prerequisites that 

--- a/_posts/2013-04-09-using-message-queues-in-cloud-applications.markdown
+++ b/_posts/2013-04-09-using-message-queues-in-cloud-applications.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Using Message Queues in Cloud Applications"
-date: 2013-04-11 08:00
+title: Using Message Queues in Cloud Applications
+date: '2013-04-11 08:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Five Pillars
-- Cloud Tools
+categories: []
 ---
 {% img right pillars/pillar.png 160 160 %}
 In Wayne Walls' [recent post on parallel computing](http://www.rackspace.com/blog/pillars-of-cloudiness-no-1-parallel-computing/), message queues are mentioned as a way to achieve parallel computing in an application. In this post, we will dive into the different message queues out there and how to implement a message queue in an application.<!-- more -->

--- a/_posts/2013-04-10-autoscale-and-orchestration-the-heat-of-openstack.markdown
+++ b/_posts/2013-04-10-autoscale-and-orchestration-the-heat-of-openstack.markdown
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Autoscale and Orchestration: the Heat of OpenStack"
-date: 2013-04-11 12:00
+title: 'Autoscale and Orchestration: the Heat of OpenStack'
+date: '2013-04-11 12:00'
 comments: true
 author: Duncan McGreggor
 published: true
 categories:
-- OpenStack
-- Community
-- Open Source
-- Configuration Management
-- Autoscale
+  - OpenStack
+  - Configuration Management
 ---
 Several months before I joined Rackspace last year, there were efforts under
 way to provide an Autoscaling solution for Rackspace customers. Features that

--- a/_posts/2013-04-12-follow-rackspace-at-the-openstack-summit.markdown
+++ b/_posts/2013-04-12-follow-rackspace-at-the-openstack-summit.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Follow Rackspace at the OpenStack Summit"
-date: 2013-04-12 09:21
+title: Follow Rackspace at the OpenStack Summit
+date: '2013-04-12 09:21'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- OpenStack
+categories:
+  - OpenStack
 ---
 Rackspace will be all over the [OpenStack Summit](https://www.openstack.org/summit/portland-2013/) in Portland next week. We're so excited about so many things during the Summit! First of all, if you’ve contributed code to the OpenStack project, we want to offer you **free hosting**. Go over to [iopenedthecloud.com](http://iopenedthecloud.com) during the Summit, or stop by the Rackspace booth (booth A5) for more info. You made the code free; we’ll make your cloud free – **up to $500 per month for two years**. You can verify contributions at [http://www.ohloh.net/](http://www.ohloh.net/). I'll be at the booth and I'd love to give some free hosting away. <!-- more -->
 

--- a/_posts/2013-04-15-openstack-summit-day-1.markdown
+++ b/_posts/2013-04-15-openstack-summit-day-1.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "From the OpenStack Summit: Day 1"
-date: 2013-04-15 18:57
+title: 'From the OpenStack Summit: Day 1'
+date: '2013-04-15 18:57'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- OpenStack
+categories:
+  - OpenStack
 ---
 Greetings from the OpenStack Summit! A lot happened in the world of OpenStack today. For a recap of all of the news, check out [Niki Acosta](https://twitter.com/nikiacosta)'s [blog post](http://www.rackspace.com/blog/openstack-summit-portland-day-1-recap/) on the Rackspace Blog. Read on for a recap of some sessions I attended today! <!-- more -->
 

--- a/_posts/2013-04-16-from-the-openstack-summit-day-2.markdown
+++ b/_posts/2013-04-16-from-the-openstack-summit-day-2.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "From the OpenStack Summit: Day 2"
-date: 2013-04-16 18:39
+title: 'From the OpenStack Summit: Day 2'
+date: '2013-04-16 18:39'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- OpenStack
+categories:
+  - OpenStack
 ---
 Day two of the OpenStack Summit was even better than the first. It kicked off with a welcome from Jonathan Bryce, Executive Director of the OpenStack Foundation, who set the tone for the day's events. We then heard from companies using OpenStack - Bloomberg, Best Buy, Comcast, and [HubSpot](http://www.rackspace.com/blog/how-hubspot-uses-the-open-hybrid-cloud/) all talked about using OpenStack and what OpenStack had done for their business. Jim O’Neill, HubSpot CIO, experienced network issues during his live demo - but still wanted to show off how HubSpot uses OpenStack.<!-- more -->
 

--- a/_posts/2013-04-18-from-the-openstack-summit-day-3.markdown
+++ b/_posts/2013-04-18-from-the-openstack-summit-day-3.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "From the OpenStack Summit: Day 3"
-date: 2013-04-18 10:52
+title: 'From the OpenStack Summit: Day 3'
+date: '2013-04-18 10:52'
 comments: true
 author: Hart Hoover
 published: true
 categories:
-- OpenStack
+  - OpenStack
 ---
 Day three was great, just like day one and day two before! I'd like to continue this series of posts by highlighting two sessions from the OpenStack Summit in Portland:
 

--- a/_posts/2013-04-22-cloud-monitoring-adds-pagerduty-integration.markdown
+++ b/_posts/2013-04-22-cloud-monitoring-adds-pagerduty-integration.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Cloud Monitoring Adds PagerDuty Integration"
-date: 2013-04-23 12:00
+title: Cloud Monitoring Adds PagerDuty Integration
+date: '2013-04-23 12:00'
 comments: true
 author: Justin Gallardo
 published: true
-categories: 
-- Cloud Monitoring
+categories:
+  - Cloud Monitoring
 ---
 
 {% img right 2013-04-22-cloud-monitoring-pagerduty/cloud_monitoring_pagerduty.png 160 160 %}[Cloud Monitoring](http://www.rackspace.com/cloud/monitoring/)

--- a/_posts/2013-04-22-displaying-prepared-code-with-syntax-highlighting-on-android.markdown
+++ b/_posts/2013-04-22-displaying-prepared-code-with-syntax-highlighting-on-android.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Displaying prepared code with syntax highlighting on Android"
-date: 2013-04-23 8:00
+title: Displaying prepared code with syntax highlighting on Android
+date: '2013-04-23 8:00'
 comments: true
 author: John Davidson
 published: true
-categories: 
-- Mobile
-- Android
+categories: []
 ---
 {% img right 2013-04-23-displaying-prepared/android_logo.jpg 150 150 %}
 

--- a/_posts/2013-04-22-love-magic-apis.markdown
+++ b/_posts/2013-04-22-love-magic-apis.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Love, Magic, & APIs"
-date: 2013-04-22 8:00
+title: 'Love, Magic, & APIs'
+date: '2013-04-22 8:00'
 comments: true
 author: Jason Gignac
 published: true
-categories: 
-- API
+categories: []
 ---
 I will confess, I am old enough to remember my GeoCities page. Don't hate. It was amazing, it was... this transformative moment in which I took real, actual information, and transformed it into something visible and memorable. I once heard someone say the GeoCities was nothing but the interior locker door of the early Internet. I agree, if you remove the words “nothing but” and pronounce the sentence with a nostalgic sense of awe. That was, and still is, the heart of the web - the convenient, interactive display of data to the multitudes. I respect (even worship) the idea of the Internet as a sort of Universal Library. On that note, if you haven't donated to Wikipedia yet, go do it.  
  

--- a/_posts/2013-04-25-getting-started-with-hadoop-using-hortonworks-sandbox.markdown
+++ b/_posts/2013-04-25-getting-started-with-hadoop-using-hortonworks-sandbox.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Getting started with Hadoop using Hortonworks Sandbox"
-date: 2013-04-25 8:00
+title: Getting started with Hadoop using Hortonworks Sandbox
+date: '2013-04-25 8:00'
 comments: true
 author: Sudarshan Acharya
 published: true
-categories:
-- Big Data
-- Hadoop
+categories: []
 ---
 {% img right 2013-04-25-getting-started-with-hadoop/hortonworks.jpg 200 200 %}
 

--- a/_posts/2013-04-26-thoughts-from-chefconf-day-1.markdown
+++ b/_posts/2013-04-26-thoughts-from-chefconf-day-1.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Thoughts from ChefConf: Day 1"
-date: 2013-04-26 8:00
+title: 'Thoughts from ChefConf: Day 1'
+date: '2013-04-26 8:00'
 comments: true
 author: Jason Smith
 published: true
-categories: 
-- Chef
-- Automation
+categories:
+  - Chef
+  - Automation
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png %}
 Hello from Sunny San Francisco! Today is day 1 of ChefConf, a Devops focused convention. Developers and Engineers come to ChefConf to learn about Opscode's latest features and learn from their peers. Below I'll talk about a few of the sessions I attended today. 

--- a/_posts/2013-04-29-join-us-at-the-appium-mobile-testing-hackathon.markdown
+++ b/_posts/2013-04-29-join-us-at-the-appium-mobile-testing-hackathon.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Join Us At The Appium Mobile Testing Hackathon"
-date: 2013-04-29 14:44
+title: Join Us At The Appium Mobile Testing Hackathon
+date: '2013-04-29 14:44'
 comments: true
 author: Alexander Scammon
 published: true
-categories: 
-- Events
+categories:
+  - Events
 ---
 Here at Rackspace we are deeply committed to furthering the software development community. We love things like well-tested applications and vibrant open source projects.
 

--- a/_posts/2013-04-29-speed-up-with-redis.markdown
+++ b/_posts/2013-04-29-speed-up-with-redis.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Improving your site speed with Redis"
-date: 2013-04-29 8:00
+title: Improving your site speed with Redis
+date: '2013-04-29 8:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Redis
-- RedisToGo
+categories: []
 ---
 {% img right 2013-04-29-speed-up-with-redis/redis_logo.png 200 200 %}
 Adding Redis to your application stack is a fantastic way to gain speed with existing applications. Many of our customers aren't running the latest and greatest new hotness NoSQL-using cloud thing. A lot of them port over a full stack of an existing applications that once only existed on bare metal servers, or use a hybrid environment with a big MySQL configuration on bare metal with web/app servers in the cloud.

--- a/_posts/2013-04-30-connect-objectrocket-to-cloud-servers.markdown
+++ b/_posts/2013-04-30-connect-objectrocket-to-cloud-servers.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Connect ObjectRocket to Cloud Servers"
-date: 2013-04-30 07:51
+title: Connect ObjectRocket to Cloud Servers
+date: '2013-04-30 07:51'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Cloud Servers
-- ObjectRocket
-- MongoDB
+categories:
+  - Cloud Servers
 ---
 ObjectRocket, the industrial strength MongoDB database-as-a-service company that Rackspace acquired in February, is now available in our Chicago data center. This means that you can now use ObjectRocket as part of your Rackspace deployments. You can read about the new data center here and a recent performance benchmark study that we did [here](http://devops.rackspace.com/benchmarking-hosted-mongodb-services.html).
 

--- a/_posts/2013-05-01-bootstrapping-chef-on-windows.markdown
+++ b/_posts/2013-05-01-bootstrapping-chef-on-windows.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Bootstrapping Chef on Windows"
-date: 2013-05-01 09:25
+title: Bootstrapping Chef on Windows
+date: '2013-05-01 09:25'
 comments: true
 author: Edward Adame
 published: true
-categories: 
-- Chef
-- Windows
+categories:
+  - Chef
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png "Chef Logo" %}
 Windows presents some challenges when it comes to using deployment automation tools.  If you’ve used 'knife-rackspace' to create Linux servers on our cloud, you know that the bootstrap process happens automatically.  The server is created, a connection is made via SSH, the Chef client is installed, and the server role is assigned… all with a single command.  If you spin up a Windows server, knife-rackspace still attempts to bootstrap the server via SSH… and this will obviously fail.  So what next?  What are your options, and which approach will produce the best results?<!-- more -->

--- a/_posts/2013-05-02-chef-conference-recap.markdown
+++ b/_posts/2013-05-02-chef-conference-recap.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Chef Conference Recap"
-date: 2013-05-02 21:43
+title: Chef Conference Recap
+date: '2013-05-02 21:43'
 comments: true
 author: Jason Smith
 published: true
 categories:
-- Chef
-- Automation
+  - Chef
+  - Automation
 ---
 {% img right 2013-05-02-chef-conference-recap/opscode_wings.png 250 200  %}
 DevOps and automation are all the rage now a days and [Chef](http://opscode.com/chef) is at the forefront. I spent Thursday and Friday of last week at [ChefConf](http://chefconf.com) in San Francisco and heard some amazing presentations. The presentations were all recorded and are available on [YouTube](http://www.youtube.com/user/Opscode).

--- a/_posts/2013-05-02-powerclient-rackspace-cloud-api-powershell-client.markdown
+++ b/_posts/2013-05-02-powerclient-rackspace-cloud-api-powershell-client.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "PowerClient: Rackspace Cloud API Powershell Client"
-date: 2013-05-02 07:39
+title: 'PowerClient: Rackspace Cloud API Powershell Client'
+date: '2013-05-02 07:39'
 comments: true
 author: Mitch Robins
 published: true
-categories: 
-- Cloud Servers
-- Windows
+categories:
+  - Cloud Servers
 ---
 ##Update (July 16, 2015)
 

--- a/_posts/2013-05-05-building-a-net-sdk-for-openstack.markdown
+++ b/_posts/2013-05-05-building-a-net-sdk-for-openstack.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Building A .NET SDK For OpenStack"
-date: 2013-05-06 08:00
+title: Building A .NET SDK For OpenStack
+date: '2013-05-06 08:00'
 comments: true
 author: Alan Quillin
 published: true
-categories: 
-- OpenStack
-- .NET
+categories:
+  - OpenStack
 ---
 As developers on the [RackConnect](http://www.rackspace.com/cloud/hybrid/dedicated_cloud/rackconnect/) product, my team has a strong need for RackConnect to interact with OpenStack when we launched the next generation public cloud. RackConnect is written in .NET, and we began baking pieces of a rudimentary .NET software development kit (SDK) functionality into our software to help use the OpenStack services. 
 

--- a/_posts/2013-05-06-jclouds-1-6-0.markdown
+++ b/_posts/2013-05-06-jclouds-1-6-0.markdown
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "jclouds 1.6.0"
-date: 2013-05-06 12:00
+title: jclouds 1.6.0
+date: '2013-05-06 12:00'
 comments: true
 author: Everett Toews
 published: true
-categories: 
-- Java
-- SDK
-- jclouds
+categories:
+  - Java
+  - SDK
+  - jclouds
 ---
 jclouds 1.6.0 has been released! Since 1.5.0 I'm both proud and (antonymically) humbled to have become a committer. We've done a lot of work since then, including adding new features and an extensive refactoring aimed at simplifying the code base and removing cruft. I'm pleased to announce that full support for Rackspace Cloud Load Balancers and Cloud DNS has been added. That brings the list of supported APIs to:
 

--- a/_posts/2013-05-06-rackspace-presents-at-devopsdays-austin-2013.markdown
+++ b/_posts/2013-05-06-rackspace-presents-at-devopsdays-austin-2013.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Rackspace presents at DevopsDays Austin 2013"
-date: 2013-05-06 15:00
+title: Rackspace presents at DevopsDays Austin 2013
+date: '2013-05-06 15:00'
 comments: true
 author: Nicholas Mistry
 published: true
-categories: 
-- Events
+categories:
+  - Events
 ---
 Last week, Austin hosted [DevOpsDays](http://devopsdays.org/), an DevOps-focused event featuring innovative talks and great networking, with some great music and food thrown in the mix. The two-day event focused on sharing ideas to strengthen the DevOps movement by building a culture around highly agile and productive teams with integrated development and operations.<!-- more -->
 

--- a/_posts/2013-05-06-using-a-build-pipeline.markdown
+++ b/_posts/2013-05-06-using-a-build-pipeline.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Using A Build Pipeline"
-date: 2013-05-07 08:00
+title: Using A Build Pipeline
+date: '2013-05-07 08:00'
 comments: true
 author: Hart Hoover
 published: true
 categories:
-- Jenkins
+  - Jenkins
 ---
 As [discussed previously](http://devops.rackspace.com/the-new-devops-blog.html), this blog is hosted entirely in [Cloud Files](http://www.rackspace.com/cloud/files/). It is powered by [Octopress](http://octopress.org), which means it is static - perfect for hosting in an object store. Our "architecture" looks like this:
 

--- a/_posts/2013-05-09-devops-improved-productivity.markdown
+++ b/_posts/2013-05-09-devops-improved-productivity.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "DevOps: Improved Productivity, Higher Value"
-date: 2013-05-10 08:00
+title: 'DevOps: Improved Productivity, Higher Value'
+date: '2013-05-10 08:00'
 comments: true
 author: James Turnbull
 published: true
-categories: 
-- Puppet
+categories:
+  - Puppet
 ---
 {% img right 2013-05-10-devopsreport/devopsreport.png 200 %}
 Those of us who have been aligned with DevOps for some time already know that the greater agility and closer collaboration it enables deliver real business value for our organizations.

--- a/_posts/2013-05-09-why-do-devs-like-openstack.markdown
+++ b/_posts/2013-05-09-why-do-devs-like-openstack.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Why Do Devs like OpenStack?"
-date: 2013-05-09 08:00
+title: Why Do Devs like OpenStack?
+date: '2013-05-09 08:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- OpenStack
+categories:
+  - OpenStack
 ---
 [Kord Campbell](http://www.stackgeek.com/) ([@stackgeek](http://twitter.com/stackgeek)) recently interviewed some developers at our San Francisco office about why they like working with OpenStack. We liked it so much we wanted to share it with you. Enjoy!<!-- more -->:
 

--- a/_posts/2013-05-13-rackspace-announces-sdk-support.markdown
+++ b/_posts/2013-05-13-rackspace-announces-sdk-support.markdown
@@ -1,17 +1,13 @@
 ---
 layout: post
-title: "Rackspace Announces SDK Support"
-date: 2013-05-13 10:20
+title: Rackspace Announces SDK Support
+date: '2013-05-13 10:20'
 comments: true
 author: Hart Hoover
 published: true
 categories:
-- pyrax
-- fog
-- jclouds
-- pkgcloud
-- php-opencloud
-- SDK
+  - jclouds
+  - SDK
 ---
 Over on the [Rackspace Blog](http://www.rackspace.com/blog) we've announced that we are now offering support to developers writing applications on our cloud infrastructure:
 

--- a/_posts/2013-05-13-rackspace-announces-sdk-support.markdown
+++ b/_posts/2013-05-13-rackspace-announces-sdk-support.markdown
@@ -5,10 +5,9 @@ date: 2013-05-13 10:20
 comments: true
 author: Hart Hoover
 published: true
-categories: 
+categories:
 - pyrax
 - fog
-- openstack.net
 - jclouds
 - pkgcloud
 - php-opencloud

--- a/_posts/2013-05-14-release-of-pkgcloud.markdown
+++ b/_posts/2013-05-14-release-of-pkgcloud.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Plans for the (v0.8?) release of pkgcloud"
-date: 2013-05-14 08:57
+title: Plans for the (v0.8?) release of pkgcloud
+date: '2013-05-14 08:57'
 comments: true
 author: Ken Perkins
 published: true
-categories: 
-- SDK
-- pkgcloud
-- node.js
+categories:
+  - SDK
+  - node.js
 ---
 It’s been a few crazy weeks since I started at Rackspace, and while I’ve already been to San Antonio multiple times, as well as attending my first OpenStack Summit and meeting all of the awesome folks at the SF Rackspace office, I’ve spent the majority of my time getting up to speed on [pkgcloud](http://github.com/nodejitsu/pkgcloud).
 

--- a/_posts/2013-05-16-cloud-betamax.markdown
+++ b/_posts/2013-05-16-cloud-betamax.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Cloud Betamax"
-date: 2013-05-16 09:08
+title: Cloud Betamax
+date: '2013-05-16 09:08'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- GCE
-- General
+categories:
+  - General
 ---
 {% img right 2013-05-16-cloud-betamax/betamax.gif 200 %}
 As part of the [Google I/O keynote yesterday](http://thenextweb.com/insider/2013/05/15/everything-announced-at-the-google-io-2013-keynote-in-one-handy-list/?), several new features for Google Compute Engine were announced. First, GCE is now available to everyone in a preview and available for signups. They also announced Cloud Datastore, a NoSQL database solution and several other features.

--- a/_posts/2013-05-17-pkgcloud-update.markdown
+++ b/_posts/2013-05-17-pkgcloud-update.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "pkgcloud update"
-date: 2013-05-17 09:23
+title: pkgcloud update
+date: '2013-05-17 09:23'
 comments: true
 author: Ken Perkins
 published: true
-categories: 
-- pkgcloud
-- SDK
-- node.js
+categories:
+  - SDK
+  - node.js
 ---
 As we hinted at in our [post earlier this week](http://devops.rackspace.com/release-of-pkgcloud.html), Rackspace is working towards an official release of node.js SDK bindings for the Rackspace Cloud. I thought it was important to provide more clarity on exactly what we're doing and why. 
 

--- a/_posts/2013-05-20-enforcing-performance-with-flood.markdown
+++ b/_posts/2013-05-20-enforcing-performance-with-flood.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Enforcing Performance With Flood"
-date: 2013-05-20 08:00
+title: Enforcing Performance With Flood
+date: '2013-05-20 08:00'
 comments: true
 author: Ian Good
 published: true
-categories: 
-- node.js
-- Performance
-- Jenkins
+categories:
+  - node.js
+  - Jenkins
 ---
 
 As we describe our release frequencies with "times per day" instead of "times

--- a/_posts/2013-05-21-cloud-files-update-new-features.markdown
+++ b/_posts/2013-05-21-cloud-files-update-new-features.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Cloud Files Update: New Features"
-date: 2013-05-21 8:00
+title: 'Cloud Files Update: New Features'
+date: '2013-05-21 8:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Cloud Files
-- API
+categories:
+  - Cloud Files
 ---
 {% img right 2013-05-21-cloud-files/cloud_files_logo.png 250 %}
 

--- a/_posts/2013-05-22-qbox.markdown
+++ b/_posts/2013-05-22-qbox.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Unleash the Power of Auto-Complete"
-date: 2013-05-22 15:30
+title: Unleash the Power of Auto-Complete
+date: '2013-05-22 15:30'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- ElasticSearch
-- Qbox
-- Startups
+categories: []
 ---
 It’s no secret that Rackspace has taken an interest in innovative startups that can get their arms around emerging Big Data technologies, package them in a hosted environment and sell them as a service. The trend is good for customers who won’t have to build and scale out infrastructure. It’s good for stimulating open technologies. It’s good for our partners in the [Rackspace Startup Program][1]. And it’s good for Rackspace.
 

--- a/_posts/2013-05-23-using-logstash-to-push-metrics-to-graphite.markdown
+++ b/_posts/2013-05-23-using-logstash-to-push-metrics-to-graphite.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Using logstash to Push Metrics to Graphite"
-date: 2013-05-23 8:00
+title: Using logstash to Push Metrics to Graphite
+date: '2013-05-23 8:00'
 comments: true
 author: Erik Redding
 published: true
-categories: 
-- Graphite
-- Logstash
+categories: []
 ---
 {% img right 2013-05-23-logstash/data-visualization-logo.png 200 %}
 One of the cool things we do on the [Cloud Databases](http://www.rackspace.com/cloud/databases/) operations side of the house is come up with statistics that can help us gain insight to hardware performance to identify issues with systems. We use some really cool tools, but one of the most versatile tools we work with is [logstash](http://www.logstash.net/). The goal of this article is to get you started pushing metrics with logstash that you may already collect to [Graphite](http://graphite.wikidot.com/). Along the way, I'll be showing you how to get started with logstash, test your configuration locally and then start pushing your first metrics to Graphite with some different examples along the way.<!-- more -->

--- a/_posts/2013-05-24-cloud-databases-vs-mysql-on-cloud-servers.markdown
+++ b/_posts/2013-05-24-cloud-databases-vs-mysql-on-cloud-servers.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Cloud Databases vs. MySQL on Cloud Servers"
-date: 2013-05-24 12:00
+title: Cloud Databases vs. MySQL on Cloud Servers
+date: '2013-05-24 12:00'
 comments: true
 author: Edward Adame
 published: true
 categories:
-- Cloud Servers
-- Cloud Databases
-- mysql
+  - Cloud Servers
 ---
 If you need to run MySQL on the Rackspace Cloud, you have two fundamental choices: run MySQL on a Cloud Server, or run MySQL as a Cloud Database instance. This naturally raises a few questions: What are the features and benefits of each? Which performs better? Which will be more cost effective? As with every application, the answer is ”it depends;” however, the information below should help you make the right choice based on your needs.<!-- more -->
 

--- a/_posts/2013-05-24-gluecon-2013-day-1.markdown
+++ b/_posts/2013-05-24-gluecon-2013-day-1.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Gluecon 2013 Day 1: Distributed Systems, APIs and Automation"
-date: 2013-05-24 8:00
+title: 'Gluecon 2013 Day 1: Distributed Systems, APIs and Automation'
+date: '2013-05-24 8:00'
 comments: true
 author: Wayne Walls
 published: true
 categories:
-- Gluecon
-- Developers
-- DevOps
+  - Developers
+  - DevOps
 ---
 {% img right 2013-05-24-gluecon/glue_logo.png %}
 [Gluecon 2013](http://www.gluecon.com/2013/) is off to a dazzling start in Broomfeild, Colo. at the beautiful [Omni Interlocken Resort](http://www.omnihotels.com/FindAHotel/DenverInterlocken.aspx). 

--- a/_posts/2013-05-28-gluecon-2013-day2.markdown
+++ b/_posts/2013-05-28-gluecon-2013-day2.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Gluecon 2013 Day 2: CEOs Who Code, Enterprise Software Evolution and API Secrets Revealed"
-date: 2013-05-30 11:03
+title: 'Gluecon 2013 Day 2: CEOs Who Code, Enterprise Software Evolution and API Secrets Revealed'
+date: '2013-05-30 11:03'
 comments: true
 author: Wayne Walls
 published: true
-categories: 
--  Gluecon
--  Developers
--  DevOps
+categories:
+  - Developers
+  - DevOps
 ---
 {% img right 2013-05-24-gluecon/glue_logo.png %}
 The second day of Gluecon 2013 started off with a bang with a great keynote presentation from [Lew Cirne]( https://twitter.com/sweetlew), CEO of [New Relic]( http://newrelic.com/) and [Stephen O’Grady](https://twitter.com/sogrady) of Redmonk.  Day two was packed with compelling topics including enterprise software history, CEOs who love to code, why to API and a further introduction to Google Compute Engine.  <!-- more -->

--- a/_posts/2013-05-28-ios-security-key-signing.markdown
+++ b/_posts/2013-05-28-ios-security-key-signing.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "iOS Security Key Signing"
-date: 2013-05-28 08:35
+title: iOS Security Key Signing
+date: '2013-05-28 08:35'
 comments: true
 author: Tokunbo George
 published: true
-categories: 
-- Mobile
-- iOS
+categories: []
 ---
 {% img right 2013-05-28-ios-security-key-signing/xcode_icon.png 200 %}
 At Rackspace, we're working very hard to support the ever-growing platform of mobile. We're working hard to design a cloud-based mobile platform for developers and on the next generation of our mobile applications. Over the years we have developed a number mobile applications to interact with our services, but we recently made a conscious decision to improve them to more "fanatical" standards.

--- a/_posts/2013-05-30-python-continuous-documentation.markdown
+++ b/_posts/2013-05-30-python-continuous-documentation.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Python Continuous Documentation"
-date: 2013-05-30 08:00
+title: Python Continuous Documentation
+date: '2013-05-30 08:00'
 comments: true
 author: Ian Good
 published: true
-categories: 
-- Python
-- Documentation
+categories:
+  - Python
 ---
 
 A well-documented Python library is something to be proud of. Reading through

--- a/_posts/2013-06-05-how-i-use-cloud-files.markdown
+++ b/_posts/2013-06-05-how-i-use-cloud-files.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Customer Story: How I use Cloud Files"
-date: 2013-06-05 09:23
+title: 'Customer Story: How I use Cloud Files'
+date: '2013-06-05 09:23'
 author: Brad Montgomery
 comments: true
 published: true
-categories: 
-- Cloud Files
+categories:
+  - Cloud Files
 ---
 {% img right 2013-05-21-cloud-files/cloud_files_logo.png 250 %}
 I've been using Cloud Files for about two years, and I thought I'd share some

--- a/_posts/2013-06-08-unlocked-intro.markdown
+++ b/_posts/2013-06-08-unlocked-intro.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Learn How To Cloud At Unlocked: The Hybrid Cloud"
-date: 2013-06-10 08:00
+title: 'Learn How To Cloud At Unlocked: The Hybrid Cloud'
+date: '2013-06-10 08:00'
 comments: true
 author: Wayne Walls
 published: true
-categories: 
-- unlocked
-- Developers
-- DevOps
-- CloudExpo
+categories:
+  - Developers
+  - DevOps
 ---
 {% img right 2013-06-08-unlocked-intro/UnlockedHybridCloudLogo.jpg 250 %}
 

--- a/_posts/2013-06-12-rackspace-autoscale-is-now-open-source.markdown
+++ b/_posts/2013-06-12-rackspace-autoscale-is-now-open-source.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Rackspace Autoscale Is Now Open Source"
-date: 2013-06-12 12:39
+title: Rackspace Autoscale Is Now Open Source
+date: '2013-06-12 12:39'
 comments: true
 author: Felix Sargent
 published: true
 categories:
-- Autoscale
-- Cloud Servers
-- Cloud Monitoring
+  - Cloud Servers
+  - Cloud Monitoring
 ---
 Our Autoscale project -- codenamed "otter" -- is now open source.
 

--- a/_posts/2013-06-14-marconi-and-salt.markdown
+++ b/_posts/2013-06-14-marconi-and-salt.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Marconi and Salt, part 1"
-date: 2013-06-14 07:45
+title: 'Marconi and Salt, part 1'
+date: '2013-06-14 07:45'
 comments: true
 author: Oz Akan
 published: true
-categories: 
-- SaltStack
-- Marconi
-- OpenStack
+categories:
+  - OpenStack
 ---
 When Henry Ford invented the assembly line at his automobile company he changed the world as we know it. It wasn’t the automobile itself that sparked that dramatic change; it was the mass production of the automobile that enabled people to go wherever they wanted whenever they wanted that created a world of possibilities. The automobile was not the final product; it was the great tool to build new products on top of it. And the ability to create a million copies of that great tool gave birth to the industrial age.
 Our story starts with cloud computing era when IT finally gets rid of the boundaries of physical environments but still finds itself incapable of delivering the "great tool" quickly enough to the people who are building new products on top of it. The great tools in this story are computers or better put, servers configured for specific purposes.

--- a/_posts/2013-06-17-rackspace-sdk-update.markdown
+++ b/_posts/2013-06-17-rackspace-sdk-update.markdown
@@ -1,17 +1,13 @@
 ---
 layout: post
-title: "Rackspace SDK Update"
-date: 2013-06-18 09:21
+title: Rackspace SDK Update
+date: '2013-06-18 09:21'
 comments: true
 author: Jesse Noller
 published: true
-categories: 
-- SDK
-- Fog
-- pyrax
-- pkgcloud
-- jclouds
-- php-opencloud
+categories:
+  - SDK
+  - jclouds
 ---
 {% img right 2013-06-17-rackspace-sdk-update/gear.png 200 %}
 

--- a/_posts/2013-06-18-indiegogo.markdown
+++ b/_posts/2013-06-18-indiegogo.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Indiegogo uses Rackspace and Chef to handle massive traffic"
-date: 2013-06-19 08:00
+title: Indiegogo uses Rackspace and Chef to handle massive traffic
+date: '2013-06-19 08:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Chef
-- Cloud Servers
+categories:
+  - Chef
+  - Cloud Servers
 ---
 {% img right 2013-01-09-cooking-with-chef/chef_logo.png "Chef Logo" %}
 

--- a/_posts/2013-06-19-using-new-relic-with-clb.markdown
+++ b/_posts/2013-06-19-using-new-relic-with-clb.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Using New Relic with Rackspace Cloud Load Balancers"
-date: 2013-06-19 16:16
+title: Using New Relic with Rackspace Cloud Load Balancers
+date: '2013-06-19 16:16'
 comments: true
 author: Jim Battenberg
 published: true
-categories: 
-- New Relic
-- Cloud Load Balancers
+categories: []
 ---
 {% img right 2013-06-20-new-relic-clb/logo-new_relic.gif 200 %}
 New Relic just released its “[New Relic Platform][1]” product consisting of more than 50 plugins from various ISVs and cloud companies.  The first Rackspace plugin to be released is for our Cloud Load Balancer product, which allows you to see HTTP vs. HTTPS traffic, easily set alerts to your predefined thresholds, and periodically check the health of the nodes associated with your load balancer to ensure they are responding correctly.

--- a/_posts/2013-06-21-marconi-and-salt-part-2.markdown
+++ b/_posts/2013-06-21-marconi-and-salt-part-2.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Marconi and Salt: Part 2"
-date: 2013-06-21 09:51
+title: 'Marconi and Salt: Part 2'
+date: '2013-06-21 09:51'
 comments: true
 author: Oz Akan
 published: true
-categories: 
-- Marconi
-- OpenStack
-- SaltStack
+categories:
+  - OpenStack
 ---
 In the [first article][1] we configured salt-master and created a Cloud Server. In this article we will start building up the Marconi environment and while doing so shape what our salt configuration will look like. 
 

--- a/_posts/2013-06-24-puppet-triage-a-thon.markdown
+++ b/_posts/2013-06-24-puppet-triage-a-thon.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
 title: "Squash Bugs at Puppet's Triage-a-Thon 2013"
-date: 2013-06-24 09:33
+date: '2013-06-24 09:33'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Puppet
+categories:
+  - Puppet
 ---
 {% img right 2013-06-24-puppet-triage/puppet_logo.png %}
 If you are interested in contributing to [Puppet][1], the upcoming "Triage-a-Thon" will be a great chance! Puppet Labs is throwing a bug squashing party on July 13th at their headquarters in Portland. Goals for the event:

--- a/_posts/2013-06-25-rackspace-deployment-services.markdown
+++ b/_posts/2013-06-25-rackspace-deployment-services.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Rackspace Deployment Services: Blueprints To Easily Launch Your Apps"
-date: 2013-06-25 13:00
+title: 'Rackspace Deployment Services: Blueprints To Easily Launch Your Apps'
+date: '2013-06-25 13:00'
 comments: true
 author: Ziad Sawalha
 published: true
-categories: 
-- Rackspace Deployment Services
+categories: []
 ---
 Early last year, a project code-named Checkmate was created by Rackers to make it easy for them to deploy complex cloud configurations, such as scalable WordPress with Cloud Servers, Cloud Databases and a Cloud Load Balancer, with one-click for our customers. The goal of the project was to provide a way for Rackers to share and collaborate on these best practices using common collaboration tools like GitHub. 
 

--- a/_posts/2013-06-25-scheduled-images-on-the-open-cloud.markdown
+++ b/_posts/2013-06-25-scheduled-images-on-the-open-cloud.markdown
@@ -5,50 +5,51 @@ date: 2013-07-02 08:00
 comments: true
 author: Brian Rosmaita
 published: true
-categories: Cloud Servers
+categories:
+  - Cloud Servers
 ---
-So there's this feature in our first generation  Cloud Servers called "backup schedules;" you may 
-have heard of it.  A lot of people liked it so much that they told us 
-they didn't want to move to the Rackspace Open Cloud until we built 
-something like it there.  So we did.  We're calling this feature 
-"Scheduled Images." <!-- more --> 
- 
-First, let me explain what this feature does: it takes a daily snapshot of your server 
-without any intervention by you.   Whether the resulting image is a 
+So there's this feature in our first generation  Cloud Servers called "backup schedules;" you may
+have heard of it.  A lot of people liked it so much that they told us
+they didn't want to move to the Rackspace Open Cloud until we built
+something like it there.  So we did.  We're calling this feature
+"Scheduled Images." <!-- more -->
+
+First, let me explain what this feature does: it takes a daily snapshot of your server
+without any intervention by you.   Whether the resulting image is a
 backup depends on what you've got going on in your server.
-For instance, with some RDBMS software, simply copying the files 
-underlying a running database and restoring those files is not a good 
-idea if you want a working database, so this feature may not be 
-suitable for all backup scenarios. 
- 
-Second, about  scheduling:  with this feature, the image is 
-scheduled by us, and we don't tell you when since it's subject to 
-change at any time.  The reason for this is that we don't want 
+For instance, with some RDBMS software, simply copying the files
+underlying a running database and restoring those files is not a good
+idea if you want a working database, so this feature may not be
+suitable for all backup scenarios.
+
+Second, about  scheduling:  with this feature, the image is
+scheduled by us, and we don't tell you when since it's subject to
+change at any time.  The reason for this is that we don't want
 automatic snapshots to interfere with normal cloud image operations or to
-adversely affect throughput througout the cloud.  We can spread out 
-the load more equitably and increase the probability of successfully  taking scheduled 
-images  if we make the schedule ourselves. 
- 
-Third, there is one configuration option, the "retention" value.  It's 
-the number of scheduled images that your account will retain. 
-When a new automatic snapshot has been taken successfully, the 
-scheduled images service will remove the oldest scheduled images until 
-the retention value is reached.  The retention value can be 
-independently set for each of your servers. 
- 
-Finally, there's no charge for using the scheduled images service--you 
-simply pay for the storage of your scheduled images at the same rate 
-you pay for storing your regular snapshots. 
- 
-Scheduled images can be activated for any of your servers by using the 
-Cloud Control Panel, the Cloud Servers API (with the Rackspace 
-Scheduled Images Extension) or by using the python-novaclient (with 
-the Rackspace Scheduled Images Novaclient extension). It's a very simple feature to understand and 
+adversely affect throughput througout the cloud.  We can spread out
+the load more equitably and increase the probability of successfully  taking scheduled
+images  if we make the schedule ourselves.
+
+Third, there is one configuration option, the "retention" value.  It's
+the number of scheduled images that your account will retain.
+When a new automatic snapshot has been taken successfully, the
+scheduled images service will remove the oldest scheduled images until
+the retention value is reached.  The retention value can be
+independently set for each of your servers.
+
+Finally, there's no charge for using the scheduled images service--you
+simply pay for the storage of your scheduled images at the same rate
+you pay for storing your regular snapshots.
+
+Scheduled images can be activated for any of your servers by using the
+Cloud Control Panel, the Cloud Servers API (with the Rackspace
+Scheduled Images Extension) or by using the python-novaclient (with
+the Rackspace Scheduled Images Novaclient extension). It's a very simple feature to understand and
 use.  
 
-The following links tell you pretty much everything you need to 
+The following links tell you pretty much everything you need to
 know to use it:
- 
-*  [Rackspace Scheduled Images API Extension documentation](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ch_extensions.html#scheduled_images) 
-*  [Using the python-novaclient to manage scheduled images](http://www.rackspace.com/knowledge_center/article/using-python-novaclient-to-manage-scheduled-images) 
-*  [The Scheduled Images FAQ](http://www.rackspace.com/knowledge_center/article/scheduled-images-faq) 
+
+*  [Rackspace Scheduled Images API Extension documentation](http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ch_extensions.html#scheduled_images)
+*  [Using the python-novaclient to manage scheduled images](http://www.rackspace.com/knowledge_center/article/using-python-novaclient-to-manage-scheduled-images)
+*  [The Scheduled Images FAQ](http://www.rackspace.com/knowledge_center/article/scheduled-images-faq)

--- a/_posts/2013-06-25-scheduled-images-on-the-open-cloud.markdown
+++ b/_posts/2013-06-25-scheduled-images-on-the-open-cloud.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: "Scheduled Images On The Open Cloud"
-date: 2013-07-02 08:00
+title: Scheduled Images On The Open Cloud
+date: '2013-07-02 08:00'
 comments: true
 author: Brian Rosmaita
 published: true

--- a/_posts/2013-06-27-php-opencloud-1-5-8.markdown
+++ b/_posts/2013-06-27-php-opencloud-1-5-8.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "php-opencloud Now Supports Cloud Monitoring &amp; OpenStack Heat"
-date: 2013-06-28 08:00
+title: 'php-opencloud Now Supports Cloud Monitoring &amp; OpenStack Heat'
+date: '2013-06-28 08:00'
 comments: true
 author: Hart Hoover
 published: true
 titlecase: false
-categories: 
-- SDK
-- php-opencloud
+categories:
+  - SDK
 ---
 Version 1.5.8 of [php-opencloud][1] is now available. In this release the PHP SDK now supports [OpenStack Heat][2] as well as [Rackspace Cloud Monitoring][3]. You can read the [release notes][4] for information related on what has changed. In this post, we will take a look at how to set up a Cloud Monitoring alarm using php-opencloud.<!-- more --> More documentation on configuring Cloud Monitoring is available in the php-opencloud [docs][5].
 

--- a/_posts/2013-07-03-thoughts-on-nodeconf-2013.markdown
+++ b/_posts/2013-07-03-thoughts-on-nodeconf-2013.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Thoughts on NodeConf 2013, 4-Square, and The Auld Triangle"
-date: 2013-07-04 08:00
+title: 'Thoughts on NodeConf 2013, 4-Square, and The Auld Triangle'
+date: '2013-07-04 08:00'
 comments: true
 author: Ken Perkins
 published: true
 categories:
-- node.js
-- Events
+  - node.js
+  - Events
 ---
 In a way, the bus ride 90 minutes north of San Francisco set the table for what the attendees had in store for the 4 days we’d spend in the hills of Marin County. There were introductions, stories swapped, jokes made, and sights to be seen. But the most significant part of the bus ride  was that most of the attendees were all experiencing it together.
 

--- a/_posts/2013-07-09-marconi-and-salt-part-3.markdown
+++ b/_posts/2013-07-09-marconi-and-salt-part-3.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Marconi and Salt: Part 3"
-date: 2013-07-09 16:13
+title: 'Marconi and Salt: Part 3'
+date: '2013-07-09 16:13'
 comments: true
 author: Oz Akan
 published: true
 categories:
-- Marconi
-- OpenStack
-- SaltStack
+  - OpenStack
 ---
 In the [second article](http://developer.rackspace.com/blog/marconi-and-salt-part-2.html), we configured three environments: a `base` environment will have very generic formulas, which we would like to apply to all servers we will ever create with Salt. A `marconi-base` environment will have formulas that are identical in all Marconi environments. For example, the way we will install MongoDB isn't different in a production environment than a development environment so we will place MongoDB formulas in a `marconi-base` environment. There is a little trick here, that I mentioned in the previous article; we will never use a `marconi-base` environment but will use it in an overlay setup with the third environment, `marconi-preview-ord`. Let's go over the folder structure to make this a little more clear.<!-- more -->
 

--- a/_posts/2013-07-11-agile-application-support-the-toyota-way.markdown
+++ b/_posts/2013-07-11-agile-application-support-the-toyota-way.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Agile Application Support - The Toyota Way"
-date: 2013-07-11 11:14
+title: Agile Application Support - The Toyota Way
+date: '2013-07-11 11:14'
 comments: true
 author: Kyle Claypool
 published: true
-categories:
-- Agile
-- Scrum
-- Lean
+categories: []
 ---
 Agile. Scrum. Extreme programming. RAD. Lean. These terms all represent a departure from the traditional Waterfall development process in favor of a more rapid, iterative approach to application development. For companies with large-scale web applications, there are significant benefits to the agile methodology, but it also presents significant challenges. 
 

--- a/_posts/2013-07-12-join-the-great-salt-sprint.markdown
+++ b/_posts/2013-07-12-join-the-great-salt-sprint.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Join the Great Salt Sprint"
-date: 2013-07-12 10:24
+title: Join the Great Salt Sprint
+date: '2013-07-12 10:24'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- SaltStack
-- OpenStack
+categories:
+  - OpenStack
 ---
 {% img right 2013-07-12-join-the-great-salt-sprint/saltstack_logo.jpg 250 %}
 

--- a/_posts/2013-07-16-ruby-on-rails-tutorial-for-the-rackspace-cloud.markdown
+++ b/_posts/2013-07-16-ruby-on-rails-tutorial-for-the-rackspace-cloud.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Ruby on Rails Tutorial for the Rackspace Cloud"
-date: 2013-07-16 10:18
+title: Ruby on Rails Tutorial for the Rackspace Cloud
+date: '2013-07-16 10:18'
 comments: true
 author: Damon Cali
 published: true
 categories:
-- Ruby
+  - Ruby
 ---
 
 At Rackspace, our goal is to support our customers in any way we can. To move towards that goal, we decided to create a couple of tutorials aimed at beginning to intermediate Ruby on Rails developers. We hope that in sharing some knowledge, we will be able to help you better achieve your own goals.

--- a/_posts/2013-07-19-openstack-miniconf-at-pycon-au-2013.markdown
+++ b/_posts/2013-07-19-openstack-miniconf-at-pycon-au-2013.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "OpenStack Miniconf at Pycon AU 2013"
-date: 2013-07-19 10:15
+title: OpenStack Miniconf at Pycon AU 2013
+date: '2013-07-19 10:15'
 comments: true
 author: Ed Leafe
 published: true
 categories:
-- Python
-- Conferences
-- OpenStack
-- PyCon
+  - Python
+  - OpenStack
 ---
 
 Friday was the pre-conference day, with two miniconfs: one for Django, and the other for OpenStack. While I'd love to spend some time digging deeper into Django, I figured that given my background as an OpenStack developer, the **OpenStack miniconf** was for me.

--- a/_posts/2013-07-21-rackspace-at-oscon.markdown
+++ b/_posts/2013-07-21-rackspace-at-oscon.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Rackspace at OSCON"
-date: 2013-07-21 08:00
+title: Rackspace at OSCON
+date: '2013-07-21 08:00'
 comments: true
 author: Jason Smith
 published: true
 categories:
-- FOSS
-- Developers
-- DevOps
-- Open Source
+  - Developers
+  - DevOps
 ---
 {% img right 2013-07-21-rackspace-at-oscon/oscon2013.png 250 %}
 

--- a/_posts/2013-07-22-a-look-back-at-pycon-australia-2013.markdown
+++ b/_posts/2013-07-22-a-look-back-at-pycon-australia-2013.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "A Look Back at PyCon Australia 2013"
-date: 2013-07-22 17:00
+title: A Look Back at PyCon Australia 2013
+date: '2013-07-22 17:00'
 comments: true
 author: Ed Leafe
 published: true
-categories: 
-- Python
-- PyCon
+categories:
+  - Python
 ---
 In an earlier [post][1] I reviewed the OpenStack miniconf that preceded the main PyCon, which was held in Hobart, Tasmania on July 6–7. I had meant to write this shortly after PyCon ended, but the whirlwind of travel back to the US and getting back into the daily grind pushed it off my plate.
 

--- a/_posts/2013-07-22-unlocked-pdxupdate.markdown
+++ b/_posts/2013-07-22-unlocked-pdxupdate.markdown
@@ -5,16 +5,16 @@ date: 2013-07-22 10:24
 comments: true
 author: Wayne Walls
 published: true
-categories: 
+categories:
 - DevOps
 - unlocked
 - Developers
-- cloud
 ---
 
-###London Unlocked Update
+### London Unlocked Update
+
 Last week we wrapped the second stop of Unlocked: The Hybrid Cloud in beautiful London, and I want to give you quick recap on the event.
-In our best turnout so far, we had over 100 developers, engineers and business executives join us who were eager to learn about all things cloud. The London event was a little different than the first in NYC. Based on feedback from NYC attendees, we split the London Unlocked event into dual tracks: business and technical. We wanted to test the waters and see if there was an appetite for more focused tracks, so we decided to offer it up and see what the feedback was like. 
+In our best turnout so far, we had over 100 developers, engineers and business executives join us who were eager to learn about all things cloud. The London event was a little different than the first in NYC. Based on feedback from NYC attendees, we split the London Unlocked event into dual tracks: business and technical. We wanted to test the waters and see if there was an appetite for more focused tracks, so we decided to offer it up and see what the feedback was like.
 It was a super successful event in all regards - minus the fire alarm that caused us to evacuate for approximately 30 minutes. I'm absolutely looking forward to returning to London for the next Unlocked event (date TBD). <!-- more -->
 
 If you couldn’t make it or were not in attendance, we have made all our slides publically available on [blog.unlocked.io](http://unlocked.io). Here, you'll find the general sessions slides, included the keynote delivered by Nigel Beighton, vice president of technology and product for Rackspace UK; the Business Track presented by Rackspace Open Cloud Architect Leo Packham and Rackspace Cloud Evangelist and DevOps Engineer Jason Smith; and the Technical Track presented Rackspace University Technical Trainer Alex Brandt and myself.
@@ -25,17 +25,17 @@ For a quick video recap of the day, check out the video below!
 
 <br />
 ###What's next? Unlocked in PDX!
-The Rackspace Unlocked team is now en route to Portland for OSCON for an event this Tuesday. 
+The Rackspace Unlocked team is now en route to Portland for OSCON for an event this Tuesday.
 Our session, "Butter Up Your Application," will cover the Five Pillars of Cloudiness and how they apply to your cloud application design. We also plan to share an open source project we wrote using the principles will cover in this tutorial. This will be a developer-focused session with lots of combing through code and discussing the ups and downs we faced when designing this application: code irregularities, race conditions, continuous integration and continuous delivery, performance tradeoffs and infrastructure automation. We want to help you plan for success the next time you sit down to design a cloud application.  As an added bonus, we’ll also open-source Margarine to the world. Margarine can be used as a template to deploy your next cloud application on any cloud provider of your choice!
 If you'd like more information, the full abstract can be found [here](http://www.oscon.com/oscon2013/public/schedule/detail/31425)
-Join us at OSCON for “Butter Up Your Application” Tuesday, July 23 at 9:00 a.m. in room E142 at the Oregon Convention Center. 
+Join us at OSCON for “Butter Up Your Application” Tuesday, July 23 at 9:00 a.m. in room E142 at the Oregon Convention Center.
 
 ###Unlocked is coming to Austin
 After the Rackspace Unlocked team returns from OSCON, we'll gear up for the next installment of Unlocked: The Hybrid Cloud. This time we’re heading to Austin. This event will take place at the W Hotel Austin and will be another run of our Business and Technical tracks. If you have not registered yet, there is still time! Go over to [unlocked.io](http://unlocked.io) and secure your spot today! We have some special guest from the ATX start-up community coming to present, and we have a few other tricks up our sleeves that we can't wait to share with the vibrant tech ecosystem in one of the world’s hotbeds of entrepreneurial and engineering talent.  
 
 ###For more information or inquiries
 
-If you have any questions, comments or feedback for the Unlocked team, please reach out to any of us - we'd love to talk to you. If you have ideas on content you'd like to see more of or less of, or want to suggest a totally new topic, we'd love to hear from you! 
+If you have any questions, comments or feedback for the Unlocked team, please reach out to any of us - we'd love to talk to you. If you have ideas on content you'd like to see more of or less of, or want to suggest a totally new topic, we'd love to hear from you!
 The Unlocked team can be reached on Twitter at the following locations:
 
 * Jennifer Boles, Unlocked Global Program Manager - [@jennbolestweets](https://twitter.com/jennbolestweets)

--- a/_posts/2013-07-22-unlocked-pdxupdate.markdown
+++ b/_posts/2013-07-22-unlocked-pdxupdate.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "London Calling:  An Unlocked Update"
-date: 2013-07-22 10:24
+title: 'London Calling:  An Unlocked Update'
+date: '2013-07-22 10:24'
 comments: true
 author: Wayne Walls
 published: true
 categories:
-- DevOps
-- unlocked
-- Developers
+  - DevOps
+  - Developers
 ---
 
 ### London Unlocked Update

--- a/_posts/2013-07-22-using-ironmq.markdown
+++ b/_posts/2013-07-22-using-ironmq.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Using IronMQ for Delayed Processing and Increasing Scale"
-date: 2013-07-23 08:00
+title: Using IronMQ for Delayed Processing and Increasing Scale
+date: '2013-07-23 08:00'
 comments: true
 author: Paddy Foran
 published: true
-categories: 
-- IronMQ
-- Cloud Tools
-- Message Queues
+categories: []
 ---
 {% img right 2013-07-23-using-ironmq/ironmq.png 200 %}
 It’s an [established pattern](http://highscalability.com/blog/2012/12/17/11-uses-for-the-humble-presents-queue-er-message-queue.html) to use message queues when building scalable, extensible, and resilient systems, but a lot of developers are still unsure how to go about actually *implementing* message queues in their architectures. Worse, the number of queuing solutions makes it hard for developers to get a grasp on exactly what a queue is, what it does, and what each solution brings to the table.

--- a/_posts/2013-07-23-automate-with-ansible.markdown
+++ b/_posts/2013-07-23-automate-with-ansible.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Automate Application Updates with Ansible"
-date: 2013-07-24 12:00
+title: Automate Application Updates with Ansible
+date: '2013-07-24 12:00'
 comments: true
 author: Michael DeHaan
 published: true
-categories: 
-- Ansible
+categories:
+  - Ansible
 ---
 This is a guest post written by Michael DeHaan, CTO at [AnsibleWorks][1], a Rackspace Cloud Tools partner. AnsibleWorks provides IT orchestration solutions that simplify the way IT manages systems, applications, and infrastructure.
 

--- a/_posts/2013-07-23-introducing-rumm-a-command-line-tool-for-the-rackspace-cloud.markdown
+++ b/_posts/2013-07-23-introducing-rumm-a-command-line-tool-for-the-rackspace-cloud.markdown
@@ -1,16 +1,15 @@
 ---
 layout: post
-title: "Introducing rumm: a Command Line Tool for the Rackspace Cloud"
-date: 2013-07-23 16:00
+title: 'Introducing rumm: a Command Line Tool for the Rackspace Cloud'
+date: '2013-07-23 16:00'
 comments: true
 author: Damon Cali
 published: true
-categories: 
-- Ruby
-- DevOps
-- OpenStack
-- Cloud Servers
-- Fog
+categories:
+  - Ruby
+  - DevOps
+  - OpenStack
+  - Cloud Servers
 ---
 
 When building a non-trivial application, you will need to manage assets in the cloud. Servers, files, containers, load balancers, databases - setting these up and maintaining them is a part of your day-to-day work. You can use the Rackspace control panel to spin up a server. Or you can use the Rackspace API, and write a quick script to do what you need. Each of these tools has its ups and its downs, depending on your point of view and how you like to work.

--- a/_posts/2013-07-23-steal-my-nfc-ring-data-at-defcon-for-100-dollars-of-free-hosting-with-rackspace.markdown
+++ b/_posts/2013-07-23-steal-my-nfc-ring-data-at-defcon-for-100-dollars-of-free-hosting-with-rackspace.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Steal my NFC Ring data at DEFCON for $100 of free hosting with Rackspace."
-date: 2013-07-23 16:26
+title: Steal my NFC Ring data at DEFCON for $100 of free hosting with Rackspace.
+date: '2013-07-23 16:26'
 comments: true
 author: Jordan Rinke
 published: true
 categories:
-- DEFCON
-- Security
-- Contests
+  - Security
 ---
 
 Let me elaborate. In a world of security breaches and stolen data I prefer to embrace emerging technology and the security community as a whole instead of hide from it. I was recently sent a link for an [NFC Ring](http://www.kickstarter.com/projects/mclear/nfc-ring "NFC Ring") with some interesting features. Many, myself included, have tried to create useful NFC or RFID based wearable devices before but they were too bulky or lacked any form of security. John's idea is simple, and hopefully effective: Put your private data, on the inside. It appears to be designed in a way that the private NFC data is only accessible if your hand is open (grabbing a door knob for instance). I find this very interesting for use as another factor of auth that is fun to hack on and easy to integrate. I contacted John with an idea, and fortunately he was on board. DEFCON is next week, if there is any place to test the security and design of a product that is the place. So, the idea is this: **Steal my NFC Ring data for $100 of free hosting with Rackspace.**

--- a/_posts/2013-07-25-project-meniscus-an-update.markdown
+++ b/_posts/2013-07-25-project-meniscus-an-update.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Project Meniscus - Logging as a Service (Update)"
-date: 2013-07-25 08:00
+title: Project Meniscus - Logging as a Service (Update)
+date: '2013-07-25 08:00'
 comments: true
 author: Chad Lung
 published: true
 categories:
-- OpenStack
-- Python
+  - OpenStack
+  - Python
 ---
 
 It’s been a while since my [last post](http://developer.rackspace.com/blog/introducing-project-meniscus-the-python-event-cloud-logging-service.html) on [Project Meniscus](http://projectmeniscus.org), which is an open-source, [Apache 2 Licensed](http://www.apache.org/licenses/LICENSE-2.0.html), cloud-scale logging service that collects logging data from cloud servers and services, makes the data easily searchable through [ElasticSearch](http://www.elasticsearch.org/), and dispatches it into numerous other data stores, including [MongoDB](http://www.mongodb.org/) and [Hadoop](http://hadoop.apache.org/). Today I want to update everyone about the current status of the project and our future plans.

--- a/_posts/2013-07-29-openstack-marconi-api.markdown
+++ b/_posts/2013-07-29-openstack-marconi-api.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "OpenStack Marconi API"
-date: 2013-07-29 12:10
+title: OpenStack Marconi API
+date: '2013-07-29 12:10'
 comments: true
 author: Oz Akan
 published: true
 categories:
-- Marconi
-- OpenStack
+  - OpenStack
 ---
 ## What is Marconi?
 

--- a/_posts/2013-08-01-got-python-questions.markdown
+++ b/_posts/2013-08-01-got-python-questions.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Got Python Questions? Ask Our Experts In The Rackspace Community"
-date: 2013-08-01 08:00
+title: Got Python Questions? Ask Our Experts In The Rackspace Community
+date: '2013-08-01 08:00'
 comments: true
 author: Pat Reynolds
 published: true
-categories: 
-- Python
+categories:
+  - Python
 ---
 EDITOR’S NOTE: Update: We got some great feedback about the first AMA with Jesse, so we’re moving the discussion space for Alex’s AMA from the Community to <http://reddit.com/r/rackspace> – that way it will be easier to follow the conversation and replies. In addition, we’re tightening up the timeframe – the AMA will happen on Tuesday ONLY, and not Tuesday through Thursday as originally planned. Finally, some of the other devs who work with Alex will be lending a helping hand, so there will be plenty of developer experience on tap for everyone! Hope to see you all there next Tuesday!
 

--- a/_posts/2013-08-02-rsyslog-and-elasticsearch.markdown
+++ b/_posts/2013-08-02-rsyslog-and-elasticsearch.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "rsyslog &amp; ElasticSearch"
-date: 2013-08-02 08:00
+title: 'rsyslog &amp; ElasticSearch'
+date: '2013-08-02 08:00'
 comments: true
 author: Micah Yoder
 published: true
-categories: 
-- ElasticSearch
+categories: []
 ---
 There is a clear benefit to being able to aggregate logs from various servers and services into one place and be able to search them for any sort of arbitrary event.  Traditional syslog can aggregate logs, but aggregating events from them sometimes involves grep and convoluted regular expressions.  Logging structured data to a database makes a lot of sense.  rsyslog and ElasticSearch can do that, but figuring out how to get it to work from the rsyslog documentation can be difficult.  Let's start from the beginning.<!-- more -->
 

--- a/_posts/2013-08-06-mailgun-offers-free-email-validation-api.markdown
+++ b/_posts/2013-08-06-mailgun-offers-free-email-validation-api.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Mailgun offers Free Email Validation API for Web Forms"
-date: 2013-08-06 09:15
+title: Mailgun offers Free Email Validation API for Web Forms
+date: '2013-08-06 09:15'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Mailgun
+categories:
+  - Mailgun
 ---
 As many of you know, Rackspace acquired the transactional email provider Mailgun almost a year ago.  Mailgun has a super easy-to-use API for sending, receiving and tracking on your application emails (they also support SMTP is that's your thing).  We've blogged about Mailgun a bunch this year, and recently Mailgun was integrated into the Rackspace cloud control panel  making it that much easier to integrate Mailgun into your app (and get 50,000 free emails per month in the process).  The Mailgunners just released a new feature that we are really excited about: email validation for web forms. So today, we're reblogging their post announcing the new feature which is completely free for Rackspace and Mailgun customers.  Read on, and remember that you can enable your Mailgun account directly through the Cloud Control Panel!<!-- more -->
 

--- a/_posts/2013-08-08-continuous-integration.markdown
+++ b/_posts/2013-08-08-continuous-integration.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Continuous Integration Success Depends on Automation"
-date: 2013-08-09 08:00
+title: Continuous Integration Success Depends on Automation
+date: '2013-08-09 08:00'
 comments: true
 author: Aliza Earnshaw
 published: true
-categories: 
-- Puppet
-- Continuous Integration
+categories:
+  - Puppet
 ---
 Continuous delivery — the ability to ship new and awesome features, updates and patches to your customers more frequently — is key to getting ahead of the competition, and staying there.
 

--- a/_posts/2013-08-12-gophercloud.markdown
+++ b/_posts/2013-08-12-gophercloud.markdown
@@ -5,9 +5,9 @@ date: 2013-08-13 08:00
 comments: true
 author: Samuel A. Falvo II
 published: true
-categories: 
+categories:
 - go
-- SDKs
+- SDK
 - Developers
 ---
 {% img right 2013-08-12-gophercloud/gophercloud.png 200 %}
@@ -31,7 +31,7 @@ called [Gophercloud][7] (Mascot: gopher, check! Cloud? Check!)!
 
 Rackspace firmly believes in a tool and API ecosystem where developers in any language aren’t locked-in on the API, or code level. This is why we actively contribute to packages such as [Fog][10] (Ruby), [jclouds][11] (Java), [pkgcloud][12] (node.js) and [libcloud][13] adding OpenStack support first, and then layering on Rackspace Cloud specific extensions.
 
-[OpenStack][8] is the open source, community driven “cloud infrastructure” project that Rackspace helped found, and many other companies and individuals contribute to on a daily basis. Our investment in it is a firm belief that lock-in to proprietary systems and APIs on any level is bad for developers and actively harmful. However, we realize that it is not the only “cloud” out there – so when we look at tooling such as [Gophercloud][7], and other SDKs, devops tools, etc – we take a “what is good for the community” first approach. 
+[OpenStack][8] is the open source, community driven “cloud infrastructure” project that Rackspace helped found, and many other companies and individuals contribute to on a daily basis. Our investment in it is a firm belief that lock-in to proprietary systems and APIs on any level is bad for developers and actively harmful. However, we realize that it is not the only “cloud” out there – so when we look at tooling such as [Gophercloud][7], and other SDKs, devops tools, etc – we take a “what is good for the community” first approach.
 
 This means that supporting and making tools and SDKs – such as [Gophercloud][7] – that are designed to support many cloud hosts and help you, as an application developer not get locked into specific APIs on a code level is paramount to our ideals and goals.
 

--- a/_posts/2013-08-12-gophercloud.markdown
+++ b/_posts/2013-08-12-gophercloud.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Gophercloud: A multi-cloud software development kit for Go"
-date: 2013-08-13 08:00
+title: 'Gophercloud: A multi-cloud software development kit for Go'
+date: '2013-08-13 08:00'
 comments: true
 author: Samuel A. Falvo II
 published: true
 categories:
-- go
-- SDK
-- Developers
+  - SDK
+  - Developers
 ---
 {% img right 2013-08-12-gophercloud/gophercloud.png 200 %}
 

--- a/_posts/2013-08-15-hackathon-austin.markdown
+++ b/_posts/2013-08-15-hackathon-austin.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Hackathon Austin: Ideas, Creations, Demos... And Lots Of Coffee"
-date: 2013-08-15 08:00
+title: 'Hackathon Austin: Ideas, Creations, Demos... And Lots Of Coffee'
+date: '2013-08-15 08:00'
 comments: true
 author: Lillie Hejl
 published: true
-categories: 
-- Hackathon
-- Developers
+categories:
+  - Developers
 ---
 {% img right 2013-08-15-hackathon-austin/ATX01.jpg 300 %}
 At the crack of 9 a.m., the breakfast tacos are here, but coffee is yet to arrive. A quiet group of Rackers have already shuffled in slowly. Out of the 12 or so makeshift tables, there isn’t one that’s empty.

--- a/_posts/2013-08-16-why-i-use-saltstack.markdown
+++ b/_posts/2013-08-16-why-i-use-saltstack.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Why I Use SaltStack"
-date: 2013-08-16 08:00
+title: Why I Use SaltStack
+date: '2013-08-16 08:00'
 comments: true
 author: Allen Oster
 published: true
-categories:
-- SaltStack
+categories: []
 ---
 {% img right 2013-07-12-join-the-great-salt-sprint/saltstack_logo.jpg 200 %}
 

--- a/_posts/2013-08-19-bookstore-for-ipython-notebooks.markdown
+++ b/_posts/2013-08-19-bookstore-for-ipython-notebooks.markdown
@@ -8,8 +8,7 @@ published: true
 categories:
 - Cloud Files
 - OpenStack
-- IPython
-- OpenStack Swift
+- Python
 ---
 
 {% img 2013-08-19-bookstore-for-ipython-notebooks/IPy_header.png 'IPython logo' 'IPython logo' %}
@@ -155,5 +154,3 @@ Happy Computing!
 # About the Author
 
 Kyle Kelley is a Developer Support Engineer at Rackspace. You can follow him on twitter [@rgbkrk](http://twitter.com/rgbkrk).
-
-

--- a/_posts/2013-08-19-bookstore-for-ipython-notebooks.markdown
+++ b/_posts/2013-08-19-bookstore-for-ipython-notebooks.markdown
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "Bookstore for IPython Notebooks"
-date: 2013-08-19 08:08
+title: Bookstore for IPython Notebooks
+date: '2013-08-19 08:08'
 comments: true
 author: Kyle Kelley
 published: true
 categories:
-- Cloud Files
-- OpenStack
-- Python
+  - Cloud Files
+  - OpenStack
+  - Python
 ---
 
 {% img 2013-08-19-bookstore-for-ipython-notebooks/IPy_header.png 'IPython logo' 'IPython logo' %}

--- a/_posts/2013-08-20-using-openstack-to-speed-up-your-chef-tests.markdown
+++ b/_posts/2013-08-20-using-openstack-to-speed-up-your-chef-tests.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Using OpenStack to Speed up your Chef Tests"
-date: 2013-08-21 08:00
+title: Using OpenStack to Speed up your Chef Tests
+date: '2013-08-21 08:00'
 comments: true
 author: Ryan Richard
 published: true
-categories: 
-- OpenStack
-- Chef
+categories:
+  - OpenStack
+  - Chef
 ---
 In today's Configuration Management landscape the general motto is "infrastructure as code" and as good [devopsians](http://www.youtube.com/watch?v=Md1MDHroXGU) we should be testing our code. This blog post takes a look at test-kitchen + OpenStack to make your life of testing chef cookbooks easier, faster and fun.<!-- more -->
 

--- a/_posts/2013-08-22-automating-load-testing-to-improve-web-application-performance.markdown
+++ b/_posts/2013-08-22-automating-load-testing-to-improve-web-application-performance.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Automating Load Testing To Improve Web Application Performance"
-date: 2013-08-22 14:00
+title: Automating Load Testing To Improve Web Application Performance
+date: '2013-08-22 14:00'
 comments: true
 author: Erik Torsner
 published: true
-categories: 
-- Ops
-- Load Testing
+categories: []
 ---
 Web application performance is a moving target. During design and implementation, a lot of big and small decisions are made that affect application performance - for good and bad. You've heard it before. But since performance can be ruined many times throughout a project, good application performance simply can not be added as an extra feature at the end of a project.
 

--- a/_posts/2013-08-22-blueflood-announcement.markdown
+++ b/_posts/2013-08-22-blueflood-announcement.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Blueflood: A new Open Source Tool for Time Series Data at Scale"
-date: 2013-08-22 08:00:00
+title: 'Blueflood: A new Open Source Tool for Time Series Data at Scale'
+date: 2013-08-22T08:00:00.000Z
 comments: true
 author: James Burkhart
 published: true
 categories:
-- Blueflood
-- Cloud Monitoring
-- cassandra
+  - Cloud Monitoring
 ---
 Time series data can yield some of the most interesting and relevant information for developers, operators and businesses. But ever larger datasets coming from multiple sources are making it difficult for people to pull real, actionable intelligence from these time series streams.
 

--- a/_posts/2013-08-27-automated-deployments-now-in-the-rackspace-control-panel.markdown
+++ b/_posts/2013-08-27-automated-deployments-now-in-the-rackspace-control-panel.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Automated Deployments Now in the Rackspace Control Panel"
-date: 2013-08-27 13:40
+title: Automated Deployments Now in the Rackspace Control Panel
+date: '2013-08-27 13:40'
 comments: true
 author: Ziad Sawlha
 published: true
-categories:
-- Deployments
+categories: []
 ---
 The hardest part about using new technology is knowing where to begin. Spending hours sifting through blog posts and documentation to set up a server environment is often enough to extinguish the excitement about a new framework or application. By the same token, it is frustrating to deploy hosting architecture when you are excited to see how your latest code will perform. And no one likes having to do the same things over and over to create consistent testing, staging and production environments.
 

--- a/_posts/2013-08-28-at-puppetconf-2013.markdown
+++ b/_posts/2013-08-28-at-puppetconf-2013.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "At PuppetConf 2013, IT Automation Solutions and DevOps Culture Take The Spotlight"
-date: 2013-08-28 09:01
+title: 'At PuppetConf 2013, IT Automation Solutions and DevOps Culture Take The Spotlight'
+date: '2013-08-28 09:01'
 comments: true
 author: Greg Swift
 published: true
-categories: 
-- Puppet
-- Events
+categories:
+  - Puppet
+  - Events
 ---
 Keep Calm and Automate All The Things. If you caught up with Rackspace in San Francisco last week at PuppetConf 2013, then you saw our t-shirt swag emblazoned with this “Keep Calm” slogan. But it’s not just any old meme; it’s also the catchphrase that perfectly describes the overarching theme of the conference.
 

--- a/_posts/2013-08-30-slumlord-hosting-with-docker.markdown
+++ b/_posts/2013-08-30-slumlord-hosting-with-docker.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Slumlord Hosting with Docker"
-date: 2013-08-30 08:00
+title: Slumlord Hosting with Docker
+date: '2013-08-30 08:00'
 comments: true
 author: Hart Hoover
 published: true
-categories: 
-- Docker
+categories:
+  - Docker
 ---
 {% img right 2013-08-19-slumlord-hosting/slumlord.jpg 200 %}
 Since becoming a Racker back in 2007, one of my all time favorite websites has been [slumlordhosting.com][1]. Slumlord Hosting is a parody of really bad shared hosting environments, advertising some amazing features:

--- a/_posts/2013-09-01-installing-openstack-grizzly-in-10-minutes.markdown
+++ b/_posts/2013-09-01-installing-openstack-grizzly-in-10-minutes.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Installing OpenStack Grizzly in 10 Minutes"
-date: 2013-09-01 08:00
+title: Installing OpenStack Grizzly in 10 Minutes
+date: '2013-09-01 08:00'
 comments: true
 author: Kord Campbell
 published: true
-categories: 
-- OpenStack 
+categories:
+  - OpenStack
 ---
 
 The [OpenStack](http://www.openstack.org/software/) provides a way to turn bare metal servers into a private cloud. It's been over a year since I published the first [Install OpenStack in 10 Minutes](http://www.stackgeek.com/guides/gettingstarted.html) guide and now, nearly 10K installs later, I'm pleased to announce the quickest and easiest way yet to get an OpenStack cluster running.

--- a/_posts/2013-09-03-developer-love-welcome-to-the-rackspace-cloud-developer-discount.markdown
+++ b/_posts/2013-09-03-developer-love-welcome-to-the-rackspace-cloud-developer-discount.markdown
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "Developer love: Welcome to the Rackspace Cloud Developer Discount"
-date: 2013-09-03 06:25
+title: 'Developer love: Welcome to the Rackspace Cloud Developer Discount'
+date: '2013-09-03 06:25'
 comments: true
 author: Jesse Noller
 published: true
 categories:
-- developers
-- trial
-- discount
-- opensource
+  - developers
 ---
 
 It's time to go make something awesome, on us.

--- a/_posts/2013-09-04-chef-creating-dynamic-host-files.markdown
+++ b/_posts/2013-09-04-chef-creating-dynamic-host-files.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Creating dynamic host files with Chef"
-date: 2013-09-04 08:00
+title: Creating dynamic host files with Chef
+date: '2013-09-04 08:00'
 comments: true
 author: Sri Rajan
 published: true
-categories: 
-- Chef
-- Linux
-- Automation
+categories:
+  - Chef
+  - Automation
 ---
 
 Maintaining hosts files on standard *nix system has been traditionally done by hand. This becomes a challenge as the number of systems grow and this is more true in the Cloud model where you might add/delete servers at a higher rate.   One solution would be to use DNS and use a local zone to store your host name to IP mapping.  If you are in the automation using Chef world, here is another example on how to automatically generate the host file entries.<!-- more -->

--- a/_posts/2013-09-05-new-features-in-cloud-servers-key-pairs-and-manual-disk-partitioning.markdown
+++ b/_posts/2013-09-05-new-features-in-cloud-servers-key-pairs-and-manual-disk-partitioning.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "New Features in Cloud Servers: Key Pairs and Manual Disk Partitioning"
-date: 2013-09-05 08:00
+title: 'New Features in Cloud Servers: Key Pairs and Manual Disk Partitioning'
+date: '2013-09-05 08:00'
 comments: true
 author: Trey Hoehne
 published: true
 categories:
-- Cloud Servers
+  - Cloud Servers
 ---
 Most people would agree that more automation is a good thing, especially
 if your day to day involves any type of server administration. Saving

--- a/_posts/2013-09-06-fanatical-support-from-the-rackspace-community.markdown
+++ b/_posts/2013-09-06-fanatical-support-from-the-rackspace-community.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Fanatical Support from the Rackspace Community"
-date: 2013-09-06 08:20
+title: Fanatical Support from the Rackspace Community
+date: '2013-09-06 08:20'
 comments: true
 author: Evan Ochs
 published: true
-categories: 
-- Community
+categories: []
 ---
 Earlier this year Rackspace announced [Rackspace Developer Support](http://www.rackspace.com/blog/rackspace-developer-support-fanatical-support-for-your-code/), an exciting new service to provide "Fanatical Support For Your Code".  
 

--- a/_posts/2013-09-09-building-an-in-house-analytics-collector-with-nginx.markdown
+++ b/_posts/2013-09-09-building-an-in-house-analytics-collector-with-nginx.markdown
@@ -1,15 +1,11 @@
 ---
 layout: post
-title: "Building an in-house analytics collector with nginx"
-date: 2013-09-09 09:09
+title: Building an in-house analytics collector with nginx
+date: '2013-09-09 09:09'
 comments: true
 author: Gabriel Preda
 published: true
-categories: 
-- nginx
-- Ops
-- logrotate
-- HAProxy
+categories: []
 ---
 There is a bigger need of web analytics out there than any single provider can offer (pun intended). Our in-house analytics system was tightly coupled into our web application because it grew along with it. It was about time we decoupled the analytics system.
 

--- a/_posts/2013-09-10-introducing-loggerfs.markdown
+++ b/_posts/2013-09-10-introducing-loggerfs.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Introducing LoggerFS"
-date: 2013-09-10 09:15
+title: Introducing LoggerFS
+date: '2013-09-10 09:15'
 comments: true
 author: Eric Cheek
 published: true
-categories: 
-- Go
-- Ops
-- Logging
+categories: []
 ---
 > WARNING: LoggerFS PROJECT HAS BEEN ABANDONED BY ITS MAINTAINER.
 

--- a/_posts/2013-09-11-11-things.markdown
+++ b/_posts/2013-09-11-11-things.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "11 Things To Remember When Writing A User Guide"
-date: 2013-09-11 13:00
+title: 11 Things To Remember When Writing A User Guide
+date: '2013-09-11 13:00'
 comments: true
 author: Don Schenck
 published: true
-categories:
-- Documentation
+categories: []
 ---
 One of the more pressing needs in the world of open source software is the need for decent documentation. That covers a lot of territory; from well-commented code (yeah… right) to API guides to the rare – some say mythical – user guide.
 

--- a/_posts/2013-09-11-simulate-symLinks-on-cloud-files.markdown
+++ b/_posts/2013-09-11-simulate-symLinks-on-cloud-files.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Simulate SymLinks on Rackspace Cloud Files"
-date: 2013-09-11 08:00
+title: Simulate SymLinks on Rackspace Cloud Files
+date: '2013-09-11 08:00'
 comments: true
 author: Sri Rajan
 published: true
-categories: 
-- Cloud Files
+categories:
+  - Cloud Files
 ---
 {% img right 2013-05-21-cloud-files/cloud_files_logo.png 250 %}
 

--- a/_posts/2013-09-16-mailgun-php-sdk-now-available.markdown
+++ b/_posts/2013-09-16-mailgun-php-sdk-now-available.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Mailgun PHP SDK Now Available"
-date: 2013-09-16 13:33
+title: Mailgun PHP SDK Now Available
+date: '2013-09-16 13:33'
 comments: true
 author: Michael Ferranti
 published: true
 categories:
-- PHP
-- Mailgun
-- SDK
+  - Mailgun
+  - SDK
 ---
 At Rackspace we've been putting a lot of work into SDKs lately. Recently the team at Mailgun joined the SDK club and released an officially supported SDK for PHP.  They are also working on SDKs for additional languages like C#, Ruby and Python which will be coming soon.
 

--- a/_posts/2013-09-16-mailgun-php-sdk-now-available.markdown
+++ b/_posts/2013-09-16-mailgun-php-sdk-now-available.markdown
@@ -5,10 +5,10 @@ date: 2013-09-16 13:33
 comments: true
 author: Michael Ferranti
 published: true
-categories: 
+categories:
 - PHP
 - Mailgun
-- SDKs
+- SDK
 ---
 At Rackspace we've been putting a lot of work into SDKs lately. Recently the team at Mailgun joined the SDK club and released an officially supported SDK for PHP.  They are also working on SDKs for additional languages like C#, Ruby and Python which will be coming soon.
 
@@ -24,7 +24,7 @@ The typical flow for using this Opt-in handler class would be as follows:
 
 **Recipient Clicks Opt In Link** -> [Validate Opt In Link] -> [Subscribe User] -> [Send final confirmation]
 
-It is best to use this class for your website subscription forms, so youâ€™ll need a web server accessible to the internet to handle the validation link click. 
+It is best to use this class for your website subscription forms, so youâ€™ll need a web server accessible to the internet to handle the validation link click.
 
 For more details check out the the full blog on [Mailgun.com][3].  And if you didn't already know, remember that Rackspace customers can use Mailgun for free, up to 50,000 emails per month.  Just click on the "More" link in the Rackspace Cloud control panel, then select Mailgun.
 

--- a/_posts/2013-09-18-using-configuration-management-to-manage-vhosts.markdown
+++ b/_posts/2013-09-18-using-configuration-management-to-manage-vhosts.markdown
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "Using configuration management to manage Vhosts"
-date: 2013-09-18 09:00
+title: Using configuration management to manage Vhosts
+date: '2013-09-18 09:00'
 comments: true
 author: Welby McRoberts
 published: true
-categories: 
-- SatlStack
-- Linux
-- IIS
-- Automation
+categories:
+  - Automation
 ---
 
 One of the challenges that someone maintaining a group of webservers is faced with is keeping the vhost configuration in sync accross all machines. Much like maitaining [hosts files](http://developer.rackspace.com/blog/chef-creating-dynamic-host-files.html) this can be solved with configuration management. There are ofcourse the usual caveats, changes made outwith of the configruation management will either be overwritern, or not syncronised between hosts, so it's imperative that those "quick changes" are actually done via the configuration management system!

--- a/_posts/2013-09-20-getting-started-with-openstack-and-designate.markdown
+++ b/_posts/2013-09-20-getting-started-with-openstack-and-designate.markdown
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "Getting Started with OpenStack and Designate"
-date: 2013-09-20 09:18
+title: Getting Started with OpenStack and Designate
+date: '2013-09-20 09:18'
 comments: true
 author: Tim Simmons
 published: true
-categories: 
-- OpenStack
-- Designate
-- DNS
-
+categories:
+  - OpenStack
 ---
 
 **Note**: This guide has been merged into the official Designate documentation. You can see that document here:

--- a/_posts/2013-09-25-developers-celebrate-collaboration.markdown
+++ b/_posts/2013-09-25-developers-celebrate-collaboration.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Developers: Celebrate Collaboration, Innovation At Yahoo! Hack USA"
-date: 2013-09-25 13:58
+title: 'Developers: Celebrate Collaboration, Innovation At Yahoo! Hack USA'
+date: '2013-09-25 13:58'
 comments: true
 author: Troy Toman
 published: true
-categories: 
-- Events
+categories:
+  - Events
 ---
 Developers and hackers are driving innovation and building great things. As Stephen O’Grady writes in his book, developers are the “[New Kingmakers][1]” and are heralding a new era in the technology world.
 

--- a/_posts/2013-09-26-using-openstack-dns-for-domain-name-resolution.markdown
+++ b/_posts/2013-09-26-using-openstack-dns-for-domain-name-resolution.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Using Openstack DNS for Domain Name Resolution"
-date: 2013-09-26 08:00
+title: Using Openstack DNS for Domain Name Resolution
+date: '2013-09-26 08:00'
 comments: true
 author: Tim Simmons
 published: true
-categories: 
-- OpenStack
-- DNS
-- Designate
+categories:
+  - OpenStack
 ---
 *Last week, you saw a guide on [Getting Started with OpenStack and Designate][11] that covered the basic setup for getting a Domain Name Server up and running using Openstack DNS's solution, Designate. Today we'll dive into actually using Designate to resolve your domain names.*
  

--- a/_posts/2013-10-02-hack4good-and-make-the-world-better.markdown
+++ b/_posts/2013-10-02-hack4good-and-make-the-world-better.markdown
@@ -5,14 +5,14 @@ date: 2013-10-02 08:38
 comments: true
 author: Vyjayanthi Vadrevu
 published: true
-categories: 
-- Event
+categories:
+- Events
 ---
 Our love for developers knows no limits – we host and support hackathons, offer [free cloud services][1] and [offer them the support they need to build awesome things][2].
 
 This weekend, we’re at it again. Rackspace is a gold sponsor of [#Hack4Good][4], a global hackathon hosted by [Geeklist][4] that focuses solely on bringing together the best engineers, designers, project builders and entrepreneurs in the world to build projects that help humanity. The goal is simple: #Hack4Good wants to make the world a better place.<!-- more -->
 
-Previous #Hack4Good projects include solving some of society’s most serious problems and challenges like disaster communication, autism learning, hunger, earthquake emergency solutions and more. The grand prize winner of the June’s first #Hack4Good hackathon was Good Neighbor, a service that allows communities in small neighborhoods to post requests for needs, services, giveaways and notifications to raise community awareness and encourage neighbors to help each other. 
+Previous #Hack4Good projects include solving some of society’s most serious problems and challenges like disaster communication, autism learning, hunger, earthquake emergency solutions and more. The grand prize winner of the June’s first #Hack4Good hackathon was Good Neighbor, a service that allows communities in small neighborhoods to post requests for needs, services, giveaways and notifications to raise community awareness and encourage neighbors to help each other.
 
 The global event is October 4 through October 6 in multiple cities including London, Los Angeles, Moscow, New York, Paris, Tel Aviv and many more. You can see the full lineup [here][3]. You’ll find Rackers rolling up our sleeves and hacking in San Francisco at Pivotal Labs, 875 Howard St.
 

--- a/_posts/2013-10-02-hack4good-and-make-the-world-better.markdown
+++ b/_posts/2013-10-02-hack4good-and-make-the-world-better.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Hack4Good And Make The World Better"
-date: 2013-10-02 08:38
+title: Hack4Good And Make The World Better
+date: '2013-10-02 08:38'
 comments: true
 author: Vyjayanthi Vadrevu
 published: true
 categories:
-- Events
+  - Events
 ---
 Our love for developers knows no limits – we host and support hackathons, offer [free cloud services][1] and [offer them the support they need to build awesome things][2].
 

--- a/_posts/2013-10-03-neutron-networking-the-building-blocks-of-an-openstack-cloud.markdown
+++ b/_posts/2013-10-03-neutron-networking-the-building-blocks-of-an-openstack-cloud.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Neutron Networking: The Building Blocks of an OpenStack Cloud"
-date: 2013-10-03 08:56
+title: 'Neutron Networking: The Building Blocks of an OpenStack Cloud'
+date: '2013-10-03 08:56'
 comments: true
 author: James Denton
 published: true
-categories: 
-- OpenStack
-- Networking
-- Neutron
-- Cloud Networks
+categories:
+  - OpenStack
+  - Neutron
+  - Cloud Networks
 ---
 In this multi-part walkthrough series, I intend to dive into the various components of the OpenStack Neutron project, and to also provide working examples of multiple networking configurations for clouds built with Rackspace Private Cloud powered by OpenStack on Ubuntu 12.04 LTS. When possible, I’ll provide configuration file examples for those following along on an install from source.
 

--- a/_posts/2013-10-04-grace-hopper-and-openstack.markdown
+++ b/_posts/2013-10-04-grace-hopper-and-openstack.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Grace Hopper and OpenStack"
-date: 2013-10-04 08:56
+title: Grace Hopper and OpenStack
+date: '2013-10-04 08:56'
 comments: true
 author: Anne Gentle
 published: true
-categories: 
-- OpenStack
-- Events
+categories:
+  - OpenStack
+  - Events
 ---
 
 This is my first time going to the Grace Hopper Celebration of Women in Computing. I've never been to a conference where they take over men's bathrooms to give women fewer lines! There are over 4500 people registered for the conference in Minneapolis. I'm so proud that Rackspace is a sponsor this year as it shows real dedication to adding more women at all levels of our organization. Niki Acosta has a great <a href="http://www.rackspace.com/blog/think-big-drive-forward-inspiration-from-the-grace-hopper-celebration-for-women-in-computing/">post on the Rackspace Blog</a> talking about how great it is to be here. I know this past year has been a great one for me personally as a woman at Rackspace. Adding Diane Fleming as an API writer on OpenStack followed by Dana Bauer as a development community manager makes our team plain fun. And our fellow teammates like to remind others, "we're not just gents you know."<!-- more -->

--- a/_posts/2013-10-08-neutron-networking-simple-flat-network.markdown
+++ b/_posts/2013-10-08-neutron-networking-simple-flat-network.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Neutron Networking: Simple Flat Network"
-date: 2013-10-08 17:00
+title: 'Neutron Networking: Simple Flat Network'
+date: '2013-10-08 17:00'
 comments: true
 author: James Denton
 published: true
 categories:
-- OpenStack
-- Networking
-- Neutron
-- Cloud Networks
+  - OpenStack
+  - Neutron
+  - Cloud Networks
 ---
 
 In this multi-part walkthrough series, I intend to dive into the various components of the OpenStack Neutron project, and to also provide working examples of multiple networking configurations for clouds built with Rackspace Private Cloud powered by OpenStack on Ubuntu 12.04 LTS. When possible, I’ll provide configuration file examples for those following along on an install from source.

--- a/_posts/2013-10-14-launch-ghost-with-rackspace-deployments.markdown
+++ b/_posts/2013-10-14-launch-ghost-with-rackspace-deployments.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Launch Ghost with Rackspace Deployments"
-date: 2013-10-14 00:22
+title: Launch Ghost with Rackspace Deployments
+date: '2013-10-14 00:22'
 comments: true
 author: Ryan Walker
 published: true
-categories:
-- Deployments
+categories: []
 ---
 
 After a successful [Kickstarter](http://www.kickstarter.com/projects/johnonolan/ghost-just-a-blogging-platform) campaign with over 5,000 backers raising over $300,000, the team over at [Ghost](http://ghost.org) announced today the public availability of their much anticipated new blogging platform.

--- a/_posts/2013-10-15-my-head-in-the-clouds-with-gophercloud-and-cloud-files.markdown
+++ b/_posts/2013-10-15-my-head-in-the-clouds-with-gophercloud-and-cloud-files.markdown
@@ -8,7 +8,6 @@ published: true
 categories:
 - OpenStack
 - Gophercloud
-- Cloud
 - Files
 ---
 
@@ -66,4 +65,3 @@ Besides, having existing infrastructure for more platforms might provide the way
 especially for non-OpenStack platforms, come.
 Taken at face value, "Build it and they will come," may not always hold true.
 Sometimes, I think, folks just want a paved road to the construction site.
-

--- a/_posts/2013-10-15-my-head-in-the-clouds-with-gophercloud-and-cloud-files.markdown
+++ b/_posts/2013-10-15-my-head-in-the-clouds-with-gophercloud-and-cloud-files.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "My Head In the Clouds with Gophercloud and Cloud Files"
-date: 2013-10-15 12:00
+title: My Head In the Clouds with Gophercloud and Cloud Files
+date: '2013-10-15 12:00'
 comments: true
 author: Samuel A. Falvo II
 published: true
 categories:
-- OpenStack
-- Gophercloud
-- Files
+  - OpenStack
 ---
 
 What ever happened to Gophercloud's Cloud Files support?

--- a/_posts/2013-10-16-code-for-america-update.markdown
+++ b/_posts/2013-10-16-code-for-america-update.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Code for America Update"
-date: 2013-10-16 12:54
+title: Code for America Update
+date: '2013-10-16 12:54'
 comments: true
 author: Glen Campbell
 published: true
 categories:
-  - code for america
   - developers
-  - outreach
 ---
 
 

--- a/_posts/2013-10-16-code-for-america-update.markdown
+++ b/_posts/2013-10-16-code-for-america-update.markdown
@@ -6,9 +6,9 @@ comments: true
 author: Glen Campbell
 published: true
 categories:
-    code for america
-    developers
-    outreach
+  - code for america
+  - developers
+  - outreach
 ---
 
 

--- a/_posts/2013-10-17-the-rackspace-robot-ticket-contest.markdown
+++ b/_posts/2013-10-17-the-rackspace-robot-ticket-contest.markdown
@@ -6,9 +6,9 @@ comments: true
 author: Jesse Noller
 published: true
 categories:
-    robots
-    developers
-    contests
+  - robots
+  - developers
+  - contests
 ---
 
 {% img 2013-10-17-the-rackspace-robot-ticket-contest/robotsconflogo.png 'RobotsConf' 'RobotsConf' %}

--- a/_posts/2013-10-17-the-rackspace-robot-ticket-contest.markdown
+++ b/_posts/2013-10-17-the-rackspace-robot-ticket-contest.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "The Rackspace Robot Ticket Contest"
-date: 2013-10-17 10:23
+title: The Rackspace Robot Ticket Contest
+date: '2013-10-17 10:23'
 comments: true
 author: Jesse Noller
 published: true
 categories:
-  - robots
   - developers
-  - contests
 ---
 
 {% img 2013-10-17-the-rackspace-robot-ticket-contest/robotsconflogo.png 'RobotsConf' 'RobotsConf' %}

--- a/_posts/2013-10-21-ruby-treats-for-october.markdown
+++ b/_posts/2013-10-21-ruby-treats-for-october.markdown
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Ruby Treats For October"
-date: 2013-10-23 09:00
+title: Ruby Treats For October
+date: '2013-10-23 09:00'
 comments: true
 author: Kyle Rames
 published: true
 categories:
-- fog
-- vagrant-rackspace
-- rumm
-- ruby
-- devops
+  - ruby
+  - devops
 ---
 
 Here are the latest Ruby treats from the Developer Relations Group.

--- a/_posts/2013-10-24-profiling-tagging-conditional-content-in-docbook.markdown
+++ b/_posts/2013-10-24-profiling-tagging-conditional-content-in-docbook.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "DocBook Tips: Profiling (Conditional Content)"
-date: 2013-10-24 10:00
+title: 'DocBook Tips: Profiling (Conditional Content)'
+date: '2013-10-24 10:00'
 comments: true
 author: Diane Fleming
 published: true
-categories:
-- docbook
-- profiling
+categories: []
 ---
 
 Diane Fleming works heavily on the OpenStack API documentation - in this post

--- a/_posts/2013-10-30-openstack-heat-orchestration-coming-to-rackspace.markdown
+++ b/_posts/2013-10-30-openstack-heat-orchestration-coming-to-rackspace.markdown
@@ -1,18 +1,14 @@
 ---
 layout: post
-title: "OpenStack Heat Orchestration coming to Rackspace"
-date: 2013-10-30 11:11
+title: OpenStack Heat Orchestration coming to Rackspace
+date: '2013-10-30 11:11'
 comments: true
 author: Chris Spencer
 published: true
 categories:
-- Apps
-- Automation
-- Deployment
-- Orchestration
-- Heat
-- OpenStack
-- Template
+  - Automation
+  - Orchestration
+  - OpenStack
 ---
 
 In the spirit of both furthering our position within the [OpenStack](http://www.openstack.org) cloud arena

--- a/_posts/2013-10-31-happy-birthday-cloud-block-storage.markdown
+++ b/_posts/2013-10-31-happy-birthday-cloud-block-storage.markdown
@@ -6,7 +6,6 @@ comments: true
 author: Jerry Schwartz
 published: true
 categories:
-- cloud
 - Cloud Block Storage
 - cbs
 - storage
@@ -87,4 +86,3 @@ We have learned a lot from our customers this past year and will be making a
 number of exciting announcements over the next several months. We’re thrilled
 about our Cloud Block Storage offering and how it is benefiting our customers,
 and we look forward to celebrating many more birthdays in the future.
-

--- a/_posts/2013-10-31-happy-birthday-cloud-block-storage.markdown
+++ b/_posts/2013-10-31-happy-birthday-cloud-block-storage.markdown
@@ -1,15 +1,11 @@
 ---
 layout: post
-title: "Happy Birthday Cloud Block Storage!"
-date: 2013-10-31 10:27
+title: 'Happy Birthday Cloud Block Storage!'
+date: '2013-10-31 10:27'
 comments: true
 author: Jerry Schwartz
 published: true
-categories:
-- Cloud Block Storage
-- cbs
-- storage
-- pricing
+categories: []
 ---
 
 We launched [Cloud Block Storage](http://www.rackspace.com/cloud/block-storage/)

--- a/_posts/2013-11-04-php-opencloud-1-dot-7-0-is-now-out.markdown
+++ b/_posts/2013-11-04-php-opencloud-1-dot-7-0-is-now-out.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "PHP OpenCloud 1.7.0 is now out"
-date: 2013-11-04 10:00
+title: PHP OpenCloud 1.7.0 is now out
+date: '2013-11-04 10:00'
 comments: true
 author: Jamie Hannaford
 published: true
 categories:
-- phpopencloud
-- php
-- sdk
-- developers
+  - sdk
+  - developers
 ---
 
 We've just let PHP OpenCloud v1.7.0 into the wild, so it would be great to give some details of the SDK's new abilities. I've written a [changelog](https://github.com/rackspace/php-opencloud/blob/master/docs/changelog/1.7.0.md) of features, plus an [upgrade guide](https://github.com/rackspace/php-opencloud/blob/master/docs/changelog/Upgrading%20to%201.7.0.md) for any folks who are daunted with the prospect of updating their codebase.

--- a/_posts/2013-11-04-php-opencloud-1-dot-7-0-is-now-out.markdown
+++ b/_posts/2013-11-04-php-opencloud-1-dot-7-0-is-now-out.markdown
@@ -9,7 +9,7 @@ categories:
 - phpopencloud
 - php
 - sdk
-- developer
+- developers
 ---
 
 We've just let PHP OpenCloud v1.7.0 into the wild, so it would be great to give some details of the SDK's new abilities. I've written a [changelog](https://github.com/rackspace/php-opencloud/blob/master/docs/changelog/1.7.0.md) of features, plus an [upgrade guide](https://github.com/rackspace/php-opencloud/blob/master/docs/changelog/Upgrading%20to%201.7.0.md) for any folks who are daunted with the prospect of updating their codebase.

--- a/_posts/2013-11-05-welcome-to-performance-cloud-servers-have-some-benchmarks.markdown
+++ b/_posts/2013-11-05-welcome-to-performance-cloud-servers-have-some-benchmarks.markdown
@@ -1,18 +1,12 @@
 ---
 layout: post
-title: "Welcome to Performance Cloud Servers; have some benchmarks!"
-date: 2013-11-05 06:00
+title: 'Welcome to Performance Cloud Servers; have some benchmarks!'
+date: '2013-11-05 06:00'
 comments: true
 author: Jesse Noller
 published: true
 categories:
-- performance
-- cloud servers
-- SSD
-- speed
-- benchmarks
-- announcements
-- new products
+  - cloud servers
 ---
 
 {% img right 2013-11-04-welcome-to-performance-cloud-servers/brace-yourselves.png 200 %}

--- a/_posts/2013-11-07-jclouds-is-an-apache-tlp.markdown
+++ b/_posts/2013-11-07-jclouds-is-an-apache-tlp.markdown
@@ -9,7 +9,7 @@ categories:
 - jclouds
 - java
 - sdk
-- developer
+- developers
 ---
 {% img right 2013-11-07-jclouds-is-an-apache-tlp/jclouds.jpg 200 %}
 

--- a/_posts/2013-11-07-jclouds-is-an-apache-tlp.markdown
+++ b/_posts/2013-11-07-jclouds-is-an-apache-tlp.markdown
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: "jclouds is an Apache Top Level Project"
-date: 2013-11-07 11:35
+title: jclouds is an Apache Top Level Project
+date: '2013-11-07 11:35'
 comments: true
 author: Everett Toews
 published: true
 categories:
-- jclouds
-- java
-- sdk
-- developers
+  - jclouds
+  - java
+  - sdk
+  - developers
 ---
 {% img right 2013-11-07-jclouds-is-an-apache-tlp/jclouds.jpg 200 %}
 

--- a/_posts/2013-11-08-step-by-step-walkthrough-to-using-chef-to-bootstrap-windows-nodes-on-the-rackspace-cloud.markdown
+++ b/_posts/2013-11-08-step-by-step-walkthrough-to-using-chef-to-bootstrap-windows-nodes-on-the-rackspace-cloud.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Step-by-step walkthrough to using Chef to bootstrap Windows Nodes on the Rackspace Cloud"
-date: 2013-11-08 09:30
+title: Step-by-step walkthrough to using Chef to bootstrap Windows Nodes on the Rackspace Cloud
+date: '2013-11-08 09:30'
 comments: true
 author: Nico Engelen
 published: true
 categories:
-- Chef
-- Windows
-- Configuration Management
-- Cloud Servers
+  - Chef
+  - Configuration Management
+  - Cloud Servers
 ---
 
 If you are a frequent reader of this blog you will have seen Hart's posts about "Cooking with Chef":

--- a/_posts/2013-11-11-zero-to-peanut-butter-docker-time-in-78-seconds.markdown
+++ b/_posts/2013-11-11-zero-to-peanut-butter-docker-time-in-78-seconds.markdown
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "Zero to Peanut Butter Docker Time in 78 seconds"
-date: 2013-11-11 12:00
+title: Zero to Peanut Butter Docker Time in 78 seconds
+date: '2013-11-11 12:00'
 comments: true
 author: Jesse Noller
 published: true
 categories:
-- docker
-- performance cloud servers
-- speed
-- containers
+  - docker
 ---
 
 {% img right 2013-11-11-peanut-butter-docker-time/Peanut-Butter-and-Jelly-Time-Family-Guy.gif 300 %}

--- a/_posts/2013-11-19-upload-files-directly-to-rackspace-cloud-files-from-the-browser.markdown
+++ b/_posts/2013-11-19-upload-files-directly-to-rackspace-cloud-files-from-the-browser.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Upload files directly to Rackspace Cloud Files from the browser"
-date: 2013-11-19 10:42
+title: Upload files directly to Rackspace Cloud Files from the browser
+date: '2013-11-19 10:42'
 comments: true
 author: W. Matthew Wilson
 published: true
 categories:
-- cloud files
-- javascript
-- ajax
+  - cloud files
 ---
 
 We needed to let users take files (possibly really big files) from their

--- a/_posts/2013-11-20-rackspace-cloud-intelligence-insights-in-monitoring.markdown
+++ b/_posts/2013-11-20-rackspace-cloud-intelligence-insights-in-monitoring.markdown
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "Rackspace Cloud Intelligence: Insights in Monitoring"
-date: 2013-11-20 15:55
+title: 'Rackspace Cloud Intelligence: Insights in Monitoring'
+date: '2013-11-20 15:55'
 comments: true
 author: Mary Stufflebeam
-published: True
+published: true
 categories:
-- data mining
-- cloud monitoring
-- anomaly detection
-- pattern recognition
+  - cloud monitoring
 ---
 
 Drowning in data? You probably just started monitoring your application.

--- a/_posts/2013-11-21-cloud-databases-java-developer-highlights.markdown
+++ b/_posts/2013-11-21-cloud-databases-java-developer-highlights.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Cloud Databases - Java Developer Highlights"
-date: 2013-11-21 14:10
+title: Cloud Databases - Java Developer Highlights
+date: '2013-11-21 14:10'
 comments: true
 author: Zack Shoylev
 published: true
 categories:
-- java
-- cloud databases
-- jclouds
-- mysql
+  - java
+  - jclouds
 ---
 
 Imagine a MySQL database you need not install, configure, optimize, or update.

--- a/_posts/2013-11-21-neutron-networking-vlan-provider-networks.markdown
+++ b/_posts/2013-11-21-neutron-networking-vlan-provider-networks.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Neutron Networking: VLAN Provider Networks"
-date: 2013-11-25 10:00
+title: 'Neutron Networking: VLAN Provider Networks'
+date: '2013-11-25 10:00'
 comments: true
 author: James Denton
 published: true
 categories:
-- OpenStack
-- Networking
-- Neutron
-- Cloud Networks
+  - OpenStack
+  - Neutron
+  - Cloud Networks
 ---
 
 In this multi-part blog series I intend to dive into the various components of the OpenStack Neutron project, and to also provide working examples of networking configurations for clouds built with [Rackspace Private Cloud](http://www.rackspace.com/cloud/private/) powered by [OpenStack](http://www.openstack.org) on Ubuntu 12.04 LTS.

--- a/_posts/2013-11-21-whistle-while-you-hacktx.markdown
+++ b/_posts/2013-11-21-whistle-while-you-hacktx.markdown
@@ -1,17 +1,15 @@
 ---
 layout: post
-title: "Whistle While You HackTX"
-date: 2013-11-22 13:15
+title: Whistle While You HackTX
+date: '2013-11-22 13:15'
 comments: true
 author: Everett Toews
 published: true
 categories:
-- jclouds
-- java
-- sdk
-- discount
-- perfomance
-- developers
+  - jclouds
+  - java
+  - sdk
+  - developers
 ---
 {% img center 2013-11-21-whistle-while-you-hacktx/hacktx.jpg 645 292 %}
 

--- a/_posts/2013-11-21-whistle-while-you-hacktx.markdown
+++ b/_posts/2013-11-21-whistle-while-you-hacktx.markdown
@@ -11,9 +11,9 @@ categories:
 - sdk
 - discount
 - perfomance
-- developer
+- developers
 ---
-{% img center 2013-11-21-whistle-while-you-hacktx/hacktx.jpg 645 292 %} 
+{% img center 2013-11-21-whistle-while-you-hacktx/hacktx.jpg 645 292 %}
 
 [HackTX](http://hacktx.com/) is the biggest hackathon in Texas. It's a 24 hour annual hackathon hosted by the Hacker Lounge and Technology Entrepreneurship Society student organizations at The University of Texas at Austin. It's made up of 500 hackers with $10,000 in prizes. By far, it's the biggest hackathon that I've personally attended and I was pretty damn excited to represent Rackspace as a sponsor.
 

--- a/_posts/2013-11-22-pathway-from-intern-to-racker.markdown
+++ b/_posts/2013-11-22-pathway-from-intern-to-racker.markdown
@@ -1,15 +1,11 @@
 ---
 layout: post
-title: "Pathway from intern to Racker"
-date: 2013-11-22 09:00
+title: Pathway from intern to Racker
+date: '2013-11-22 09:00'
 comments: true
 author: Anne Gentle
 published: true
-categories:
-- culture
-- rackspace
-- internship
-- stem
+categories: []
 ---
 
 **Maryam Nazari** is a software developer working on data center automation

--- a/_posts/2013-11-27-unlimited-jenkins-slaves-in-5-quick-steps.markdown
+++ b/_posts/2013-11-27-unlimited-jenkins-slaves-in-5-quick-steps.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Unlimited Jenkins Slaves in 5 Quick Steps"
-date: 2014-01-17 11:20
+title: Unlimited Jenkins Slaves in 5 Quick Steps
+date: '2014-01-17 11:20'
 comments: true
 author: Max Lincoln
 published: true
 categories:
-- Jenkins
-- jclouds
-- Deployments
+  - Jenkins
+  - jclouds
 ---
 
 Have you ever noticed long build queuing times in Jenkins?  If you have long builds and few executors, you can spend more time waiting for resources than actually testing.  If you have an existing Jenkins setup, take a look at the [ClusterStats Plugin](https://wiki.jenkins-ci.org/display/JENKINS/ClusterStats+Plugin) to keep an eye on this problem.

--- a/_posts/2013-12-02-redis-benchmark-and-rackspace-performance-vms.markdown
+++ b/_posts/2013-12-02-redis-benchmark-and-rackspace-performance-vms.markdown
@@ -1,16 +1,12 @@
 ---
 layout: post
-title: "Redis Benchmark &amp; Rackspace Performance VMs"
-date: 2013-12-09 12:30
+title: 'Redis Benchmark &amp; Rackspace Performance VMs'
+date: '2013-12-09 12:30'
 comments: true
 author: Ken Perkins
 published: true
 categories:
- - performance cloud servers
- - redis
- - benchmarks
- - node.js
-
+  - node.js
 ---
 While I was visiting the [Concurix team](http://www.concurix.com) getting a demo of
 some of the awesomeness they have for node.js profiling,

--- a/_posts/2013-12-10-understanding-the-chef-environment-file-in-rackspace-private-cloud.markdown
+++ b/_posts/2013-12-10-understanding-the-chef-environment-file-in-rackspace-private-cloud.markdown
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: "Understanding the Chef Environment File in Rackspace Private Cloud"
-date: 2013-12-10 11:01
+title: Understanding the Chef Environment File in Rackspace Private Cloud
+date: '2013-12-10 11:01'
 comments: true
 author: James Thorne
 published: true
 categories:
- - chef
- - devops
- - private cloud
- - OpenStack
+  - chef
+  - devops
+  - private cloud
+  - OpenStack
 ---
 
 Rackspace Private Cloud uses Chef to deploy an OpenStack environment. Chef

--- a/_posts/2013-12-11-chef-server-backups.markdown
+++ b/_posts/2013-12-11-chef-server-backups.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Chef server backups"
-date: 2013-12-11 10:00
+title: Chef server backups
+date: '2013-12-11 10:00'
 comments: true
 author: Sriram Rajan
 published: true
 categories:
- - Chef
- - knife-backup
+  - Chef
 ---
 
 There are few ways to backup a Chef server. Opscode has some documenation on

--- a/_posts/2014-01-06-cloud-auto-scale-java-developer-highlights.markdown
+++ b/_posts/2014-01-06-cloud-auto-scale-java-developer-highlights.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Cloud Auto Scale - Java Developer Highlights"
-date: 2014-01-15 10:30
+title: Cloud Auto Scale - Java Developer Highlights
+date: '2014-01-15 10:30'
 comments: true
 author: Zack Shoylev
 published: true
 categories:
- - jclouds
- - autoscale
+  - jclouds
 ---
 
 One of the big benefits of using the cloud to drive your applications is the

--- a/_posts/2014-01-06-postgresql-plus-wal-e-plus-cloudfiles-equals-awesome.markdown
+++ b/_posts/2014-01-06-postgresql-plus-wal-e-plus-cloudfiles-equals-awesome.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "PostgreSQL + WAL-E + Cloudfiles = Awesome"
-date: 2014-01-6 12:00
+title: PostgreSQL + WAL-E + Cloudfiles = Awesome
+date: '2014-01-6 12:00'
 comments: true
 author: Alex Gaynor
 published: true
-categories:
- - performance cloud servers
- - postgresql
+categories: []
 ---
 
 If you're a big PostgreSQL fan like I am, you may have heard of a tool called

--- a/_posts/2014-01-07-neutron-networking-l3-agent.md
+++ b/_posts/2014-01-07-neutron-networking-l3-agent.md
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Neutron Networking: Neutron Routers and the L3 Agent"
-date: 2014-01-07 15:20
+title: 'Neutron Networking: Neutron Routers and the L3 Agent'
+date: '2014-01-07 15:20'
 comments: true
 author: James Denton
 published: true
 categories:
-- OpenStack
-- Networking
-- Neutron
-- Cloud Networks
+  - OpenStack
+  - Neutron
+  - Cloud Networks
 ---
 
 In this multi-part blog series I intend to dive into the various components of the OpenStack Neutron project and provide working examples of networking configurations for clouds built with [Rackspace Private Cloud](http://www.rackspace.com/cloud/private/) powered by [OpenStack](http://www.openstack.org) on Ubuntu 12.04 LTS. 

--- a/_posts/2014-01-08-jclouds-170-released.markdown
+++ b/_posts/2014-01-08-jclouds-170-released.markdown
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: "jclouds 1.7.0 Released With Support for OpenStack Queuing, Networks, and Rackspace Auto Scale"
-date: 2014-01-08 10:00
+title: 'jclouds 1.7.0 Released With Support for OpenStack Queuing, Networks, and Rackspace Auto Scale'
+date: '2014-01-08 10:00'
 comments: true
 author: Everett Toews
 published: true
 categories:
-- jclouds
-- java
-- sdk
-- developers
-- openstack
+  - jclouds
+  - java
+  - sdk
+  - developers
+  - openstack
 ---
 {% img right 2013-11-07-jclouds-is-an-apache-tlp/jclouds.jpg 200 %}
 

--- a/_posts/2014-01-08-jclouds-170-released.markdown
+++ b/_posts/2014-01-08-jclouds-170-released.markdown
@@ -9,12 +9,12 @@ categories:
 - jclouds
 - java
 - sdk
-- developer
+- developers
 - openstack
 ---
 {% img right 2013-11-07-jclouds-is-an-apache-tlp/jclouds.jpg 200 %}
 
-Apache jclouds version 1.7.0 has been released into the wild. This is jclouds' first minor point version release as an Apache top level project. Community development on the project is continuing to accelerate and there are some major additions I'd like to highlight. 
+Apache jclouds version 1.7.0 has been released into the wild. This is jclouds' first minor point version release as an Apache top level project. Community development on the project is continuing to accelerate and there are some major additions I'd like to highlight.
 
 <br/>
 
@@ -24,7 +24,7 @@ Apache jclouds version 1.7.0 has been released into the wild. This is jclouds' f
 
 I added support for Queuing (project alias: Marconi). OpenStack Queuing is a robust, web-scale message queuing service to support the distributed nature of large web applications. At Rackspace, our implementation of it is known as [Cloud Queues](http://www.rackspace.com/cloud/queues/).
 
-Kris Sterckx from Alcatel-Lucent added support for Networking (project alias: Neutron). [OpenStack Networking](http://www.openstack.org/software/openstack-networking/) is a pluggable and scalable system for managing network resources, such as networks, subnets, and virtual network interfaces. 
+Kris Sterckx from Alcatel-Lucent added support for Networking (project alias: Neutron). [OpenStack Networking](http://www.openstack.org/software/openstack-networking/) is a pluggable and scalable system for managing network resources, such as networks, subnets, and virtual network interfaces.
 
 ## Rackspace
 

--- a/_posts/2014-01-13-upgrade-your-ghost-deployment.markdown
+++ b/_posts/2014-01-13-upgrade-your-ghost-deployment.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Upgrade Your Ghost Deployment"
-date: 2014-01-13 16:00
+title: Upgrade Your Ghost Deployment
+date: '2014-01-13 16:00'
 comments: true
 author: Ryan Walker
 published: true
-categories:
-- Deployments
+categories: []
 ---
 
 Back in October of 2013 I wrote about how to [launch Ghost with Rackspace Deployment](http://developer.rackspace.com/blog/launch-ghost-with-rackspace-deployments.html). Today, Ghost [announced](http://blog.ghost.org/ghost-0-4/) the release of thier latest version - 0.4.0. Now that Ghost has gone through a few updates, it is a good time to go over the process of updating your Ghost deployment. <!-- more -->

--- a/_posts/2014-01-15-data-day-texas-2014.markdown
+++ b/_posts/2014-01-15-data-day-texas-2014.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Data Day Texas 2014"
-date: 2014-01-24 9:00
+title: Data Day Texas 2014
+date: '2014-01-24 9:00'
 comments: true
 author: Zack Shoylev
 published: true
-categories:
- - conferences
- - ddtx14
+categories: []
 ---
 
 On Saturday (01/11) I attended Data Day Texas (#ddtx14). As per the

--- a/_posts/2014-01-21-integrate-your-zend-framework-2-app-with-rackspace-cloud.markdown
+++ b/_posts/2014-01-21-integrate-your-zend-framework-2-app-with-rackspace-cloud.markdown
@@ -1,15 +1,11 @@
 ---
 layout: post
-title: "Integrate your Zend Framework 2 app with Rackspace Cloud"
-date: 2014-01-29 10:30
+title: Integrate your Zend Framework 2 app with Rackspace Cloud
+date: '2014-01-29 10:30'
 comments: true
 author: Jamie Hannaford
 published: true
-categories:
- - php-sdk
- - php-opencloud
- - zf2
- - zend framework 2
+categories: []
 ---
 [Zend Framework 2](http://zendframework.com/) is an incredibly popular PHP framework that allows you to create web applications in an efficient, quick and robust manner. I could have chosen other web frameworks like [Symfony](http://symfony.com/), [Laravel](http://laravel.com/), [Yii](http://www.yiiframework.com/) or [CodeIgniter](http://ellislab.com/codeigniter); or even frameworks in different languages like Django or Rails, but I'll stick to personal preference for this blog post.
 

--- a/_posts/2014-01-21-software-defined-networks-in-the-havana-release-of-openstack.markdown
+++ b/_posts/2014-01-21-software-defined-networks-in-the-havana-release-of-openstack.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Software Defined Networks in the Havana release of OpenStack"
-date: 2014-01-21 11:00
+title: Software Defined Networks in the Havana release of OpenStack
+date: '2014-01-21 11:00'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
- - OpenStack
- - SDN
- - Networks
- - Neutron
+  - OpenStack
+  - Neutron
 ---
 
 

--- a/_posts/2014-01-22-cloud-files-directory-listing.markdown
+++ b/_posts/2014-01-22-cloud-files-directory-listing.markdown
@@ -1,17 +1,12 @@
 ---
 layout: post
-title: "Cloud Files directory listing"
-date: 2014-01-22 14:21
+title: Cloud Files directory listing
+date: '2014-01-22 14:21'
 comments: true
 author: Louwrens Boonstra
 published: true
 categories:
- - API
- - Cloud Files
- - Bash
- - httpie
- - jq
-
+  - Cloud Files
 ---
 
 My last holiday took me to Morocco, where me and a couple of friends used

--- a/_posts/2014-01-22-gophercloud-update.markdown
+++ b/_posts/2014-01-22-gophercloud-update.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Gophercloud Update"
-date: 2014-01-27 12:00
+title: Gophercloud Update
+date: '2014-01-27 12:00'
 comments: true
 author: Samuel A. Falvo II
 published: true
-categories:
- - gophercloud
+categories: []
 ---
 
 I'm happy to report that Gophercloud has received some contributor interest

--- a/_posts/2014-01-23-introducing-boot-dot-rackspace-dot-com.markdown
+++ b/_posts/2014-01-23-introducing-boot-dot-rackspace-dot-com.markdown
@@ -1,17 +1,13 @@
 ---
 layout: post
-title: "Introducing boot.rackspace.com"
-date: 2014-01-23 16:00
+title: Introducing boot.rackspace.com
+date: '2014-01-23 16:00'
 comments: true
 author: Antony Messerli
 published: true
-categories: 
-- Cloud Servers
-- Cloud Tools
-- Images
-- iPXE
-- OpenStack
-- Performance
+categories:
+  - Cloud Servers
+  - OpenStack
 ---
 
 We have had a number of customers request the need to be able to create their own Cloud Servers images rather than taking snapshots from our base installs.  To fulfill this need, we are announcing a new tool as a preview today called [boot.rackspace.com](http://boot.rackspace.com).  The tool enables you to utilize the various Linux distributions installers to install directly to the disk of your Cloud Server. <!-- more -->

--- a/_posts/2014-01-24-openstack-cli-basics.markdown
+++ b/_posts/2014-01-24-openstack-cli-basics.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Openstack CLI Basics"
-date: 2014-01-24 12:00
+title: Openstack CLI Basics
+date: '2014-01-24 12:00'
 comments: true
 author: Jonathan Kelly
 published: true
 categories:
- - OpenStack
- - CLI
- - Tools
+  - OpenStack
 ---
 
 

--- a/_posts/2014-01-27-automating-rackspace-cloud-with-ansible.markdown
+++ b/_posts/2014-01-27-automating-rackspace-cloud-with-ansible.markdown
@@ -12,11 +12,9 @@ categories:
  - devops
  - configuration management
  - deployment
- - developer
  - developers
  - opensource
  - python
- - cloud
  - orchestration
 ---
 

--- a/_posts/2014-01-27-automating-rackspace-cloud-with-ansible.markdown
+++ b/_posts/2014-01-27-automating-rackspace-cloud-with-ansible.markdown
@@ -1,21 +1,18 @@
 ---
 layout: post
-title: "Automating Rackspace Cloud with Ansible"
-date: 2014-01-27 13:00
+title: Automating Rackspace Cloud with Ansible
+date: '2014-01-27 13:00'
 comments: true
 author: Michael DeHaan
 published: true
 categories:
- - Ansible
- - automation
- - application deployment
- - devops
- - configuration management
- - deployment
- - developers
- - opensource
- - python
- - orchestration
+  - Ansible
+  - automation
+  - devops
+  - configuration management
+  - developers
+  - python
+  - orchestration
 ---
 
 

--- a/_posts/2014-01-28-the-dual-advantage-of-multi-cloud-toolkits.markdown
+++ b/_posts/2014-01-28-the-dual-advantage-of-multi-cloud-toolkits.markdown
@@ -11,7 +11,7 @@ categories:
 - pkgcloud
 - libcloud
 - sdk
-- developer
+- developers
 ---
 {% img right 2014-01-28-the-dual-advantage-of-multi-cloud-toolkits/multi-cloud.png 200 %}
 

--- a/_posts/2014-01-28-the-dual-advantage-of-multi-cloud-toolkits.markdown
+++ b/_posts/2014-01-28-the-dual-advantage-of-multi-cloud-toolkits.markdown
@@ -1,17 +1,14 @@
 ---
 layout: post
-title: "The Dual Advantage of Multi-Cloud Toolkits"
-date: 2014-01-30 9:30
+title: The Dual Advantage of Multi-Cloud Toolkits
+date: '2014-01-30 9:30'
 comments: true
 author: Everett Toews
 published: true
 categories:
-- jclouds
-- fog
-- pkgcloud
-- libcloud
-- sdk
-- developers
+  - jclouds
+  - sdk
+  - developers
 ---
 {% img right 2014-01-28-the-dual-advantage-of-multi-cloud-toolkits/multi-cloud.png 200 %}
 

--- a/_posts/2014-02-03-beginning-to-understand-neutron-provider-and-tenant-networks-in-openstack.markdown
+++ b/_posts/2014-02-03-beginning-to-understand-neutron-provider-and-tenant-networks-in-openstack.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Beginning to Understand Neutron Provider and Tenant Networks in OpenStack"
-date: 2014-02-03 09:23
+title: Beginning to Understand Neutron Provider and Tenant Networks in OpenStack
+date: '2014-02-03 09:23'
 comments: true
 author: James Thorne
 published: true
 categories:
- - OpenStack
- - Neutron
- - Networking
+  - OpenStack
+  - Neutron
 ---
 
 OpenStack is composed of many different projects. The core projects 

--- a/_posts/2014-02-03-libcloud-0-dot-14-released.markdown
+++ b/_posts/2014-02-03-libcloud-0-dot-14-released.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Libcloud 0.14 Released"
-date: 2014-02-03 14:51
+title: Libcloud 0.14 Released
+date: '2014-02-03 14:51'
 comments: true
 author: Brian Curtin
 published: true
 categories:
-- python
-- libcloud
-- openstack
-- apis
+  - python
+  - openstack
 ---
 
 On 22 January, [Apache Libcloud](https://libcloud.apache.org/index.html) project chair Tomaz Muraus announced the release of Libcloud 0.14, a Python package which abstracts away the many differences among cloud provider APIs, allowing developers to target one interface regardless of the vendor.

--- a/_posts/2014-02-05-using-cloud-init-with-rackspace-cloud.markdown
+++ b/_posts/2014-02-05-using-cloud-init-with-rackspace-cloud.markdown
@@ -7,8 +7,7 @@ author: Trey Hoehne
 published: true
 categories:
  - Cloud-init
- - Cloud
- - Configuration
+ - Configuration Management
  - Linux
 ---
 It goes without saying that booting and configuring a server manually

--- a/_posts/2014-02-05-using-cloud-init-with-rackspace-cloud.markdown
+++ b/_posts/2014-02-05-using-cloud-init-with-rackspace-cloud.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Using Cloud-init with Rackspace cloud"
-date: 2014-02-11 10:30
+title: Using Cloud-init with Rackspace cloud
+date: '2014-02-11 10:30'
 comments: true
 author: Trey Hoehne
 published: true
 categories:
- - Cloud-init
- - Configuration Management
- - Linux
+  - Configuration Management
 ---
 It goes without saying that booting and configuring a server manually
 every time you need one gets old fast. Thankfully there are a number of tools to help

--- a/_posts/2014-02-10-inside-my-home-rackspace-private-cloud-openstack-lab-part-1-the-setup.markdown
+++ b/_posts/2014-02-10-inside-my-home-rackspace-private-cloud-openstack-lab-part-1-the-setup.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Inside My Home Rackspace Private Cloud, OpenStack Lab, Part 1: The Setup"
-date: 2014-02-10 18:00
+title: 'Inside My Home Rackspace Private Cloud, OpenStack Lab, Part 1: The Setup'
+date: '2014-02-10 18:00'
 comments: true
 author: Kevin Jackson
 published: true
 categories:
- - OpenStack
- - Hardware
- - Private Cloud
+  - OpenStack
+  - Private Cloud
 ---
 
 Over the past year I’ve been using a home lab for quick, hands-on testing of [OpenStack](http://openstack.org) and [Rackspace Private Cloud](http://www.rackspace.com/cloud/private/), and a number of people have requested information on the setup. Throughout the next few blog posts I will explain what I’ve got. This serves two purposes: 1) documentation of my own setup as well as 2) hopefully providing information that other people find useful – and not everything is about OpenStack.

--- a/_posts/2014-02-10-software-defined-networks-in-the-havana-release-of-openstack-part-2.markdown
+++ b/_posts/2014-02-10-software-defined-networks-in-the-havana-release-of-openstack-part-2.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Software Defined Networks in the Havana release of Openstack – Part 2"
-date: 2014-02-24 09:30
+title: Software Defined Networks in the Havana release of Openstack – Part 2
+date: '2014-02-24 09:30'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
- - OpenStack
- - Havana
- - SDN
- - Neutron
+  - OpenStack
+  - Neutron
 ---
 Software Defined Networks in the Havana release of Openstack – Part 2
 

--- a/_posts/2014-02-13-givecamp-memphis.markdown
+++ b/_posts/2014-02-13-givecamp-memphis.markdown
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "GiveCamp Memphis 2014"
-date: 2014-02-18 13:40
+title: GiveCamp Memphis 2014
+date: '2014-02-18 13:40'
 comments: true
 author: Ed Leafe
 published: true
 categories:
-  - Charity
-  - Community
   - Developers
   - Events
-  - Hackathon
 ---
 
 

--- a/_posts/2014-02-13-givecamp-memphis.markdown
+++ b/_posts/2014-02-13-givecamp-memphis.markdown
@@ -7,7 +7,6 @@ author: Ed Leafe
 published: true
 categories:
   - Charity
-  - Cloud
   - Community
   - Developers
   - Events
@@ -38,7 +37,7 @@ I chose to work with the Memphis Area Coalition on Hunger along with several oth
 
 Every 4-6 hours we would have a standup to discuss where each group was, what was blocking their progress, and where we expected to be by the next standup. If a group had an issue that was blocking them, I would float over to their team for a bit to help them out. As a result I got to meet a lot more of the developers, and learn about such fun things like Google OAuth2 integration.
 
-The space at Cowork Memphis was available around the clock, and many developers chose to work through the night. That’s a younger man’s game, however, so I headed back to the hotel for some sleep around midnight. 
+The space at Cowork Memphis was available around the clock, and many developers chose to work through the night. That’s a younger man’s game, however, so I headed back to the hotel for some sleep around midnight.
 
 Saturday was pretty much non-stop development, as we worked to get something working by the end of GiveCamp. Again, I contributed little coding, but instead led many of the design discussions, and helped to keep the project moving. The design was settled, and since I'm not that great at tweaking web front ends, I worked on defining the data backend. The challenge that we had was to enter information about all of the various locations that provided food for the hungry, such as location, days/hours of operation, and whether they were child-friendly. That last data item was one of the things I learned from the organizers of the charity: since most of the hungry are poor families with small children, many services are geared toward making their service safe for small children. Many others took in anyone off the street, including people with severe mental illnesses, and you wouldn't want to send a family with small children there. Once the data was entered, people could go to the web, enter their location, and find all the services that were nearby.
 

--- a/_posts/2014-02-17-exploring-jclouds-a-python-developers-point-of-view.markdown
+++ b/_posts/2014-02-17-exploring-jclouds-a-python-developers-point-of-view.markdown
@@ -1,18 +1,16 @@
 ---
 layout: post
-title: "Exploring Apache jclouds with Groovy: A Python Developers point of view"
-date: 2014-03-05 11:00
+title: 'Exploring Apache jclouds with Groovy: A Python Developers point of view'
+date: '2014-03-05 11:00'
 comments: true
 author: John Yi
 published: true
 categories:
-- jclouds
-- sdk
-- developers
-- groovy
-- java
-- python
-
+  - jclouds
+  - sdk
+  - developers
+  - java
+  - python
 ---
 
 One of the most powerful features of Python is the REPL (Run, Evaluate, Print,

--- a/_posts/2014-02-17-exploring-jclouds-a-python-developers-point-of-view.markdown
+++ b/_posts/2014-02-17-exploring-jclouds-a-python-developers-point-of-view.markdown
@@ -8,7 +8,7 @@ published: true
 categories:
 - jclouds
 - sdk
-- developer
+- developers
 - groovy
 - java
 - python
@@ -265,4 +265,3 @@ So there you go. Again the purpose of using Groovy here is to learn jclouds
 in a Java context. You can of course explore jclouds with Jython and JRuby but
 hopefully this will give the Python/Ruby developer yet another option when
 exploring and hacking!
-

--- a/_posts/2014-02-17-understanding-the-chef-environment-file-in-rackspace-private-cloud-v4-dot-2-x-powered-by-openstack-havana.markdown
+++ b/_posts/2014-02-17-understanding-the-chef-environment-file-in-rackspace-private-cloud-v4-dot-2-x-powered-by-openstack-havana.markdown
@@ -1,16 +1,15 @@
 ---
 layout: post
-title: "Understanding the Chef Environment File in Rackspace Private Cloud v4.2.x powered by OpenStack Havana"
-date: 2014-02-17 09:43
+title: Understanding the Chef Environment File in Rackspace Private Cloud v4.2.x powered by OpenStack Havana
+date: '2014-02-17 09:43'
 comments: true
 author: James Thorne
 published: true
 categories:
- - OpenStack
- - Private Cloud
- - Chef
- - DevOps
- - Havana
+  - OpenStack
+  - Private Cloud
+  - Chef
+  - DevOps
 ---
 
 In a [previous post](http://developer.rackspace.com/blog/understanding-the-chef-environment-file-in-rackspace-private-cloud.html)

--- a/_posts/2014-03-03-the-odd-couple-mongodb-and-mysql.markdown
+++ b/_posts/2014-03-03-the-odd-couple-mongodb-and-mysql.markdown
@@ -1,15 +1,11 @@
 ---
 layout: post
-title: "The Odd Couple: MongoDB and MySQL"
-date: 2014-03-03 14:10
+title: 'The Odd Couple: MongoDB and MySQL'
+date: '2014-03-03 14:10'
 comments: true
 author: Alex Brandt
 published: true
-categories:
- - MongoDB
- - MySQL
- - Guest Posts
-
+categories: []
 ---
 
 The choices and combinations we have available during datastore selection

--- a/_posts/2014-03-03-using-rackspace-cloud-monitoring-to-help-reduce-food-waste.markdown
+++ b/_posts/2014-03-03-using-rackspace-cloud-monitoring-to-help-reduce-food-waste.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Using Rackspace Cloud Monitoring to help reduce food waste."
-date: 2014-03-03 12:00
+title: Using Rackspace Cloud Monitoring to help reduce food waste.
+date: '2014-03-03 12:00'
 comments: true
 author: Bill Hertzing
 published: true
 categories:
- - Cloud Monitoring
- - Hardware
- - RaspberryPi
+  - Cloud Monitoring
 ---
 
 Losing a large amount of food in a freezer can be a costly and grueling task

--- a/_posts/2014-03-04-devops-automation-series-images-vs-config-management.markdown
+++ b/_posts/2014-03-04-devops-automation-series-images-vs-config-management.markdown
@@ -7,7 +7,6 @@ author: Matthew Thode
 published: true
 categories:
  - DevOps
- - Cloud Images
  - Configuration Management
 ---
 

--- a/_posts/2014-03-04-devops-automation-series-images-vs-config-management.markdown
+++ b/_posts/2014-03-04-devops-automation-series-images-vs-config-management.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "DevOps Automation Series: Images vs. Config Management"
-date: 2014-03-04 15:00
+title: 'DevOps Automation Series: Images vs. Config Management'
+date: '2014-03-04 15:00'
 comments: true
 author: Matthew Thode
 published: true
 categories:
- - DevOps
- - Configuration Management
+  - DevOps
+  - Configuration Management
 ---
 
 

--- a/_posts/2014-03-09-supporting-non-profits-while-hacking-our-gig-at-the-knowbility-openair-hackathon.markdown
+++ b/_posts/2014-03-09-supporting-non-profits-while-hacking-our-gig-at-the-knowbility-openair-hackathon.markdown
@@ -1,19 +1,11 @@
 ---
 layout: post
-title: "Supporting Non-profits While Hacking: Our Gig at the Knowbility OpenAIR Hackathon"
-date: 2014-03-20 10:00
+title: 'Supporting Non-profits While Hacking: Our Gig at the Knowbility OpenAIR Hackathon'
+date: '2014-03-20 10:00'
 comments: true
 author: Emmanuel Ankutse
 published: true
-categories:
- - Volunteer
- - Accessibilty
- - Assistive Technologies
- - Hackathon
- - OpenAIR
- - Knowbility
- - Food Policy Council
- - Support Non-profit
+categories: []
 ---
 
 

--- a/_posts/2014-03-10-provisioning-users-at-rackspace.markdown
+++ b/_posts/2014-03-10-provisioning-users-at-rackspace.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Provisioning Users at Rackspace"
-date: 2014-03-10 10:30
+title: Provisioning Users at Rackspace
+date: '2014-03-10 10:30'
 comments: true
 author: Topher Marie
 published: true
 categories:
- - Devops
- - User management
- - Cloud Tools
+  - Devops
 ---
 
 **This is a guest post from Topher Marie, VP of Engineering at

--- a/_posts/2014-03-11-announcing-gophercloud-0.1.markdown
+++ b/_posts/2014-03-11-announcing-gophercloud-0.1.markdown
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Announcing Gophercloud 0.1"
-date: 2014-03-11 12:00
+title: Announcing Gophercloud 0.1
+date: '2014-03-11 12:00'
 comments: true
 author: Samuel A. Falvo II
 published: true
 categories:
- - Gophercloud
- - Go
- - SDK
- - OpenStack
- - Version
+  - SDK
+  - OpenStack
 ---
 
 I'm pleased to announce that the final PR for Gophercloud 0.1 has successfully merged to master!  Gophercloud 0.1 is out!

--- a/_posts/2014-03-17-balloon-mapping-outreach.markdown
+++ b/_posts/2014-03-17-balloon-mapping-outreach.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Balloon Mapping and Outreach"
-date: 2014-03-17 9:30
+title: Balloon Mapping and Outreach
+date: '2014-03-17 9:30'
 comments: true
-author: Anne Gentle, Dana Bauer
+author: 'Anne Gentle, Dana Bauer'
 published: true
-categories:
-- Community
-- outreach
+categories: []
 ---
 
 "What's the difference between data and a map?" This question came from

--- a/_posts/2014-03-18-elasticsearch-autodiscovery-on-the-rackspace-cloud.markdown
+++ b/_posts/2014-03-18-elasticsearch-autodiscovery-on-the-rackspace-cloud.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Elasticsearch Autodiscovery on the Rackspace Cloud"
-date: 2014-03-18 13:30
+title: Elasticsearch Autodiscovery on the Rackspace Cloud
+date: '2014-03-18 13:30'
 comments: true
 author: Ryan Richard
 published: true
 categories:
- - Elasticsearch
- - Chef
- - Autodiscovery
- - DevOps
+  - Chef
+  - DevOps
 ---
 
 

--- a/_posts/2014-03-19-cloud-block-storage-volume-cloning-announced.markdown
+++ b/_posts/2014-03-19-cloud-block-storage-volume-cloning-announced.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Cloud Block Storage Volume Cloning Announced!"
-date: 2014-03-19 10:01
+title: 'Cloud Block Storage Volume Cloning Announced!'
+date: '2014-03-19 10:01'
 comments: true
 author: Jose Malacara
 published: true
-categories:
- - Cloud Block Storage
- - Cloning
+categories: []
 ---
 
 Today our Control Panel team announced support for Cloud Block Storage Volume

--- a/_posts/2014-03-27-announcing-cloud-images.markdown
+++ b/_posts/2014-03-27-announcing-cloud-images.markdown
@@ -7,7 +7,6 @@ author: Brian Rosmaita
 published: true
 categories:
 - Cloud Servers
-- Cloud Images
 - Images
 - OpenStack
 ---

--- a/_posts/2014-03-27-announcing-cloud-images.markdown
+++ b/_posts/2014-03-27-announcing-cloud-images.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Developing with Cloud Images for Fun and Profit"
-date: 2014-04-01 11:00
+title: Developing with Cloud Images for Fun and Profit
+date: '2014-04-01 11:00'
 comments: true
 author: Brian Rosmaita
 published: true
 categories:
-- Cloud Servers
-- Images
-- OpenStack
+  - Cloud Servers
+  - OpenStack
 ---
 
 Rackspace has just launched Cloud Images, a public OpenStack Images

--- a/_posts/2014-03-31-protecting-sensitive-information-from-appearing-in-public-repos.markdown
+++ b/_posts/2014-03-31-protecting-sensitive-information-from-appearing-in-public-repos.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Protecting Sensitive Information From Appearing in Public Repos"
-date: 2014-04-15 10:30
+title: Protecting Sensitive Information From Appearing in Public Repos
+date: '2014-04-15 10:30'
 comments: true
 author: Sri Rajan
 published: true
 categories:
- - git
- - Security
- - Programming
+  - Security
 ---
 
 

--- a/_posts/2014-04-01-zero-downtime-deployments-with-pkgcloud-and-cloud-load-balancers.markdown
+++ b/_posts/2014-04-01-zero-downtime-deployments-with-pkgcloud-and-cloud-load-balancers.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Zero downtime deployments with pkgcloud and Cloud Load Balancers"
-date: 2014-04-10 12:00
+title: Zero downtime deployments with pkgcloud and Cloud Load Balancers
+date: '2014-04-10 12:00'
 comments: true
 author: Ken Perkins
 published: true
 categories:
- - cloud load balancers
- - pkgcloud
- - node.js
+  - node.js
 ---
 
 I've been spending a lot of time working on more practical examples with [pkgcloud][0], and one of the ones that I think will appeal broadly is the ability to deploy your code as part of a zero-downtime deployment strategy.

--- a/_posts/2014-04-10-can-you-really-run-a-fault-tolerant-high-performance-scale-out-sql-database-in-a-cloud.markdown
+++ b/_posts/2014-04-10-can-you-really-run-a-fault-tolerant-high-performance-scale-out-sql-database-in-a-cloud.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Can you really run a fault-tolerant, high-performance, scale-out SQL database in a cloud?"
-date: 2014-04-10 13:00
+title: 'Can you really run a fault-tolerant, high-performance, scale-out SQL database in a cloud?'
+date: '2014-04-10 13:00'
 comments: true
-author: Roland Schmidt, Sr. Director of Business Development, Clustrix, Inc.
+author: 'Roland Schmidt, Sr. Director of Business Development, Clustrix, Inc.'
 published: true
-categories:
-  - database
-  - partner
-  - clusterix
+categories: []
 ---
 
 

--- a/_posts/2014-04-15-powershell-101-from-a-linux-guy.markdown
+++ b/_posts/2014-04-15-powershell-101-from-a-linux-guy.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "PowerShell 101 From a Linux Guy"
-date: 2014-04-23 10:00
+title: PowerShell 101 From a Linux Guy
+date: '2014-04-23 10:00'
 comments: true
 author: Sriram(Sri) Rajan
 published: true
 categories:
- - windows
- - powershell
- - automation
+  - automation
 ---
 
 Having spent my last 7 years concentrating mainly on Linux and related technologies, I spent 3 days with PowerShell and here are the some observations and anecdotes.  Why PowerShell?  Curiosity for one and I wanted to learn it from a perspective of how to use it in configuration management tools like Chef. As an disclaimer, I'm not an expert in PowerShell and spending 3 days is just scraping the surface but I did learn quite a bit in that time. Also my prediction is that PowerShell will be real force (if not already) in Windows environments. It is a mindset change for several Windows administrators who have grown up on GUIs but that is about to change in the coming years. And if you are Linux administrator, you are likely to feel more comfortable interacting the PowerShell way. I definitely did.

--- a/_posts/2014-04-16-rolling-deployments-with-ansible-and-cloud-load-balancers.markdown
+++ b/_posts/2014-04-16-rolling-deployments-with-ansible-and-cloud-load-balancers.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Rolling Deployments with Ansible and Cloud Load Balancers"
-date: 2014-04-22 10:00
+title: Rolling Deployments with Ansible and Cloud Load Balancers
+date: '2014-04-22 10:00'
 comments: true
 author: Jesse Keating
 published: true
 categories:
- - cloud load balancers
- - ansible
- - pyrax
+  - ansible
 ---
 
 Recently a fellow Racker wrote a great post about [zero downtime deployments][0]. I strongly believe in the principals he described. In his example, he used Node.js to build a deployment script to accomplish the goal, and I want to explore how this could be done with [Ansible][1] and the Rackspace Cloud.

--- a/_posts/2014-05-07-cancelling-ajax-requests-in-angularjs-applications.markdown
+++ b/_posts/2014-05-07-cancelling-ajax-requests-in-angularjs-applications.markdown
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "Cancelling Ajax requests in AngularJS Applications"
-date: 2014-05-07 10:00
+title: Cancelling Ajax requests in AngularJS Applications
+date: '2014-05-07 10:00'
 comments: true
 author: Satheesh Kumar
 published: true
-categories:
- - angularjs
- - javascript
+categories: []
 ---
 
 

--- a/_posts/2014-05-08-software-defined-networks-in-the-havana-release-of-openstack-part-3.markdown
+++ b/_posts/2014-05-08-software-defined-networks-in-the-havana-release-of-openstack-part-3.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Software Defined Networks in the Havana release of Openstack – Part 3"
-date: 2014-05-08 09:30
+title: Software Defined Networks in the Havana release of Openstack – Part 3
+date: '2014-05-08 09:30'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
   - openstack
-  - networks
 ---
 
 In [part 1](http://developer.rackspace.com/blog/software-defined-networks-in-the-havana-release-of-openstack.html) of this series we looked at creation of software defined networks (SDN) in OpenStack and started considering at how OpenStack accomplishes this function. Continuing on to [part 2](http://developer.rackspace.com/blog/software-defined-networks-in-the-havana-release-of-openstack-part-2.html), we started looking at the network path of VM1 for the tenant test and how it filters traffic to secure traffic flow into and out of the virtual machine (VM). In this section we will continue examining the filtering process by looking at sample packets as they proceed through these filters and may then either enter the Open vSwitch (OVS) process or proceed on to the VM depending on the packet flow direction.

--- a/_posts/2014-05-12-installing-cinder-in-your-rackspace-private-cloud-lab-environment.markdown
+++ b/_posts/2014-05-12-installing-cinder-in-your-rackspace-private-cloud-lab-environment.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Installing Cinder in Your Rackspace Private Cloud Lab Environment"
-date: 2014-05-12 10:21
+title: Installing Cinder in Your Rackspace Private Cloud Lab Environment
+date: '2014-05-12 10:21'
 comments: true
 author: Jason Grimm
 published: true
 categories:
-  - Cinder
   - OpenStack
   - Private Cloud
 ---

--- a/_posts/2014-05-16-configuring-your-rackspace-private-cloud-lab-environment-for-cinder-testing.markdown
+++ b/_posts/2014-05-16-configuring-your-rackspace-private-cloud-lab-environment-for-cinder-testing.markdown
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Configuring Your Rackspace Private Cloud Lab Environment for Cinder testing"
-date: 2014-05-16 15:13
+title: Configuring Your Rackspace Private Cloud Lab Environment for Cinder testing
+date: '2014-05-16 15:13'
 comments: true
 author: Jason Grimm
 published: true
 categories:
-  - Cinder
   - OpenStack
 ---
 In the knowledge center article titled "KNOWLEDGE CENTER ARTICLE: INSTALLING AND TESTING CINDER IN YOUR RACKSPACE PRIVATE CLOUD LAB ENVIRONMENT" I walk through the entire process of installing, configuring and testing the OpenStack Cinder service in your RPC lab environment.

--- a/_posts/2014-05-19-on-being-a-railsconf-opportunity-scholar-guide.markdown
+++ b/_posts/2014-05-19-on-being-a-railsconf-opportunity-scholar-guide.markdown
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "On being a RailsConf Opportunity Scholar Guide"
-date: 2014-05-19 15:05
+title: On being a RailsConf Opportunity Scholar Guide
+date: '2014-05-19 15:05'
 comments: true
 author: Evan Light
 published: true
 categories:
-  - RailsConf
-  - Community
-  - Outreach
   - Ruby
 ---
 

--- a/_posts/2014-05-21-testing-cinder-in-your-rackspace-private-cloud-lab-environment.markdown
+++ b/_posts/2014-05-21-testing-cinder-in-your-rackspace-private-cloud-lab-environment.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "Testing Cinder in Your Rackspace Private Cloud Lab Environment"
-date: 2014-05-21 10:22
+title: Testing Cinder in Your Rackspace Private Cloud Lab Environment
+date: '2014-05-21 10:22'
 comments: true
 author: Jason Grimm
 published: true
 categories:
- - OpenStack
- - Cinder
- - Private Cloud
+  - OpenStack
+  - Private Cloud
 ---
 
 In the knowledge center article titled "KNOWLEDGE CENTER ARTICLE: INSTALLING AND TESTING CINDER IN YOUR RACKSPACE PRIVATE CLOUD LAB ENVIRONMENT" I walk through the entire process of installing, configuring and testing the OpenStack Cinder service in your RPC lab environment.

--- a/_posts/2014-05-22-move-fast-and-dont-break-things-testing-with-jenkins-ansible-and-docker.markdown
+++ b/_posts/2014-05-22-move-fast-and-dont-break-things-testing-with-jenkins-ansible-and-docker.markdown
@@ -8,7 +8,7 @@ published: true
 categories:
   - Docker
   - Ansible
-  - Jenkins CI
+  - Jenkins
   - Testing
 ---
 One of our highest priorities at [Mist.io](https://mist.io) is to never break production. Our users depend on it to manage and monitor their servers and we depend on them. At the same time, we need to move fast with development and deliver updates as soon as possible. We want to be able to easily deploy several times per day.

--- a/_posts/2014-05-22-move-fast-and-dont-break-things-testing-with-jenkins-ansible-and-docker.markdown
+++ b/_posts/2014-05-22-move-fast-and-dont-break-things-testing-with-jenkins-ansible-and-docker.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: "Move fast and don’t break things! Testing with Jenkins, Ansible and Docker"
-date: 2014-05-22 09:20
+title: 'Move fast and don’t break things! Testing with Jenkins, Ansible and Docker'
+date: '2014-05-22 09:20'
 comments: true
 author: Mike Muzurakis
 published: true
@@ -9,7 +9,6 @@ categories:
   - Docker
   - Ansible
   - Jenkins
-  - Testing
 ---
 One of our highest priorities at [Mist.io](https://mist.io) is to never break production. Our users depend on it to manage and monitor their servers and we depend on them. At the same time, we need to move fast with development and deliver updates as soon as possible. We want to be able to easily deploy several times per day.
 

--- a/_posts/2014-05-23-bootstrap-your-qcow-images-for-the-rackspace-public-cloud.markdown
+++ b/_posts/2014-05-23-bootstrap-your-qcow-images-for-the-rackspace-public-cloud.markdown
@@ -6,7 +6,6 @@ comments: true
 author: Mike Metral
 published: true
 categories:
-- Cloud Images
 - Custom Images
 - Public Cloud
 - QCOW

--- a/_posts/2014-05-23-bootstrap-your-qcow-images-for-the-rackspace-public-cloud.markdown
+++ b/_posts/2014-05-23-bootstrap-your-qcow-images-for-the-rackspace-public-cloud.markdown
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Bootstrap your QCOW Images for the Rackspace Public Cloud"
-date: 2014-05-23 10:30
+title: Bootstrap your QCOW Images for the Rackspace Public Cloud
+date: '2014-05-23 10:30'
 comments: true
 author: Mike Metral
 published: true
 categories:
-- Custom Images
-- Public Cloud
-- QCOW
-- VHD
-- OpenStack
+  - Public Cloud
+  - OpenStack
 ---
 
 In the world of Cloud Computing, hypervisors and disk image formats come in

--- a/_posts/2014-05-28-custom-images-via-boot-dot-rackspace-dot-com-training-wheels-included.markdown
+++ b/_posts/2014-05-28-custom-images-via-boot-dot-rackspace-dot-com-training-wheels-included.markdown
@@ -6,7 +6,6 @@ comments: true
 author: Mike Metral
 published: true
 categories:
-- Cloud Images
 - Custom Images
 - Public Cloud
 - Cloud Servers

--- a/_posts/2014-05-28-custom-images-via-boot-dot-rackspace-dot-com-training-wheels-included.markdown
+++ b/_posts/2014-05-28-custom-images-via-boot-dot-rackspace-dot-com-training-wheels-included.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Custom Images via boot.rackspace.com - Training Wheels Included"
-date: 2014-05-28 12:42
+title: Custom Images via boot.rackspace.com - Training Wheels Included
+date: '2014-05-28 12:42'
 comments: true
 author: Mike Metral
 published: true
 categories:
-- Custom Images
-- Public Cloud
-- Cloud Servers
-- OpenStack
+  - Public Cloud
+  - Cloud Servers
+  - OpenStack
 ---
 
 With the recent announcement of

--- a/_posts/2014-06-05-the-pain-of-slow-build-times.markdown
+++ b/_posts/2014-06-05-the-pain-of-slow-build-times.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "The Pain of Slow Build Times"
-date: 2014-06-05 11:54
+title: The Pain of Slow Build Times
+date: '2014-06-05 11:54'
 comments: true
 author: Matt Barlow
 published: true
 categories:
- - Rails
- - NodeJS
- - Build Times
+  - NodeJS
 ---
 
 The other day I was working on a Ruby on Rails cookbook. I used the

--- a/_posts/2014-06-11-walk-n-doc.markdown
+++ b/_posts/2014-06-11-walk-n-doc.markdown
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Walk & Doc"
-date: 2014-06-11 14:00:00+00:00
+title: 'Walk & Doc'
+date: 2014-06-11T14:00:00.000Z
 comments: true
 author: Everett Toews
 published: true
 categories:
-- jclouds
-- documentation
+  - jclouds
 ---
 {% img right 2014-06-11-walk-n-doc/pedestrian-sign.jpg %} 
  

--- a/_posts/2014-06-19-how-we-run-ironic-and-you-can-too
+++ b/_posts/2014-06-19-how-we-run-ironic-and-you-can-too
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "How we run Ironic, and you can too!"
-date: 2014-06-19 12:00
+title: 'How we run Ironic, and you can too!'
+date: '2014-06-19 12:00'
 comments: true
 author: Jim Rollenhagen
 published: true
 categories:
-    - onmetal
-    - openstack
-    - ironic
+  - openstack
 ---
 
 As you may already know, Rackspace just launched [OnMetal](http://www.rackspace.com/cloud/servers/onmetal/), which is built with OpenStack [Ironic](https://github.com/openstack/ironic) and [ironic-python-agent (IPA)](https://github.com/openstack/ironic-python-agent). I want to highlight the code, what our control plane looks like, and how we operate it. My hope is that this post can help others test and deploy Ironic with IPA.

--- a/_posts/2014-06-19-how-we-run-ironic-and-you-can-too.md
+++ b/_posts/2014-06-19-how-we-run-ironic-and-you-can-too.md
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "How we run Ironic, and you can too!"
-date: 2014-06-19 12:00
+title: 'How we run Ironic, and you can too!'
+date: '2014-06-19 12:00'
 comments: true
 author: Jim Rollenhagen
 published: true
 categories:
-    - onmetal
-    - openstack
-    - ironic
+  - openstack
 ---
 
 As you may already know, Rackspace just launched [OnMetal](http://www.rackspace.com/cloud/servers/onmetal/), which is built with OpenStack [Ironic](https://github.com/openstack/ironic) and [ironic-python-agent (IPA)](https://github.com/openstack/ironic-python-agent). I want to highlight the code, what our control plane looks like, and how we operate it. My hope is that this post can help others test and deploy Ironic with IPA.

--- a/_posts/2014-06-23-chef-metal-and-rackspace.markdown
+++ b/_posts/2014-06-23-chef-metal-and-rackspace.markdown
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Chef Metal and Rackspace"
-date: 2014-06-26 08:00
+title: Chef Metal and Rackspace
+date: '2014-06-26 08:00'
 comments: true
 author: Hart Hoover
 published: true
 categories:
-- Chef
+  - Chef
 ---
 {% img right 2014-06-23-chef-metal/chef-logo.png 160 160 %}
 

--- a/_posts/2014-06-23-from-bare-metal-to-rackspace-cloud.md
+++ b/_posts/2014-06-23-from-bare-metal-to-rackspace-cloud.md
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "From Bare Metal to Rackspace Private Cloud POC"
-date: 2014-06-23 12:00
+title: From Bare Metal to Rackspace Private Cloud POC
+date: '2014-06-23 12:00'
 comments: true
 author: James Thorne
 published: true
 categories:
-    - RPC
-    - openstack
-    - Private Cloud
+  - RPC
+  - openstack
+  - Private Cloud
 ---
 
 There are all sorts of tools available to setup virtual OpenStack environments on your workstation. 

--- a/_posts/2014-07-02-spinning-up-your-first-instance-on-rackspace-private-cloud.markdown
+++ b/_posts/2014-07-02-spinning-up-your-first-instance-on-rackspace-private-cloud.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Spinning Up Your First Instance on Rackspace Private Cloud"
-date: 2014-07-02 14:09
+title: Spinning Up Your First Instance on Rackspace Private Cloud
+date: '2014-07-02 14:09'
 comments: true
 author: James Thorne
 published: true
 categories:
- - OpenStack
- - Private Cloud 
+  - OpenStack
+  - Private Cloud
 ---
 Last week, I presented a live webinar on how to use the OpenStack Horizon Dashboard to [spin up your first instance on Rackspace Private Cloud](http://youtu.be/YZModLNABhU). The Horizon Dashboard is a simple and intuitive way to begin consuming your OpenStack environment. But, what if you want to administer and use your OpenStack environment using the OpenStack Python command line tools?
 

--- a/_posts/2014-07-09-provisioning-a-microsoft-private-cloud-with-pdt.markdown
+++ b/_posts/2014-07-09-provisioning-a-microsoft-private-cloud-with-pdt.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Provisioning a Microsoft Private Cloud with PDT"
-date: 2014-07-09 10:55
+title: Provisioning a Microsoft Private Cloud with PDT
+date: '2014-07-09 10:55'
 comments: true
 author: Andre Stephens and Todd Klindt
 published: true
 categories:
- - PDT
- - Microsoft
- - Private Cloud 
+  - Private Cloud
 ---
 Working at Rackspace, clouds are something that I think about a lot. Over the last year I've been working with the Microsoft Private Cloud. When I first went through the process of deploying an environment, it took about a week and a copious amount of swearing for the installation and integration of the System Center 2012 R2 components. To do a multitude of these deployments by hand would take a ridiculous amount of time and even more swearing. Luckily, Rob Willis, from Microsoft, wrote a powerful workflow called PowerShell Deployment Toolkit (PDT). PDT is a collection of PowerShell workflows and scripts bound together to achieve a single, glorious purpose, the deployment of System Center 2012 R2. At the time of this writing, the current version is 2.64.2611 and can be found [here](http://gallery.technet.microsoft.com/PowerShell-Deployment-f20bb605).
 

--- a/_posts/2014-07-24-i-have-a-cloud-dot-dot-dot-now-what-part-1-building-a-3-tier-webapp.markdown
+++ b/_posts/2014-07-24-i-have-a-cloud-dot-dot-dot-now-what-part-1-building-a-3-tier-webapp.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "I Have A Cloud...Now What? - Part 1: Building a 3-tier Webapp"
-date: 2014-07-24 12:26
+title: 'I Have A Cloud...Now What? - Part 1: Building a 3-tier Webapp'
+date: '2014-07-24 12:26'
 comments: true
 author: Mike Metral
 published: true
 categories:
-- public-cloud
-- cloud-servers
-- OpenStack
-- architechture
+  - public-cloud
+  - cloud-servers
+  - OpenStack
 ---
 
 When we meet with customers, a constant set of questions we get asked goes something

--- a/_posts/2014-07-29-i-have-a-cloud-dot-dot-dot-now-what-part-2-building-a-redundant-webapp-with-log-analysis.markdown
+++ b/_posts/2014-07-29-i-have-a-cloud-dot-dot-dot-now-what-part-2-building-a-redundant-webapp-with-log-analysis.markdown
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "I Have A Cloud...Now What? - Part 2: Building a Redundant Webapp with Log Analysis"
-date: 2014-07-29 11:40
+title: 'I Have A Cloud...Now What? - Part 2: Building a Redundant Webapp with Log Analysis'
+date: '2014-07-29 11:40'
 comments: true
 author: Mike Metral
 published: true
 categories:
-- public-cloud
-- cloud-servers
-- OpenStack
-- architecture
+  - public-cloud
+  - cloud-servers
+  - OpenStack
 bio: |
   Mike Metral is a Solution Architect at Rackspace in the Private Cloud R&D
   organization. Mike joined Rackspace in 2012 to help establish OpenStack as

--- a/_posts/2014-08-05-jclouds-domain-classes.md
+++ b/_posts/2014-08-05-jclouds-domain-classes.md
@@ -1,16 +1,20 @@
 ---
 layout: post
-title: "Better Builders with jclouds"
-date: 2014-08-05 23:59
+title: Better Builders with jclouds
+date: '2014-08-05 23:59'
 comments: true
 author: Zack Shoylev
 published: true
 categories:
-    - jclouds
-    - developers
-    - sdk
-bio: |
- Zack Shoylev is a committer on the Apache jclouds project and a Software Developer for Rackspace. He is currently working on   open source cloud SDK development. Zack’s technical interests focus on open source development, cloud computing, and big data  processing with Java. Zack's twitter handle: @zackshoylev and Freenode nick: zacksh
+  - jclouds
+  - developers
+  - sdk
+bio: >
+  Zack Shoylev is a committer on the Apache jclouds project and a Software
+  Developer for Rackspace. He is currently working on   open source cloud SDK
+  development. Zack’s technical interests focus on open source development, cloud
+  computing, and big data  processing with Java. Zack's twitter handle:
+  @zackshoylev and Freenode nick: zacksh
 ---
 # Better Builders with jclouds
 

--- a/_posts/2014-08-05-jclouds-domain-classes.md
+++ b/_posts/2014-08-05-jclouds-domain-classes.md
@@ -7,7 +7,7 @@ author: Zack Shoylev
 published: true
 categories:
     - jclouds
-    - development
+    - developers
     - sdk
 bio: |
  Zack Shoylev is a committer on the Apache jclouds project and a Software Developer for Rackspace. He is currently working on   open source cloud SDK development. Zack’s technical interests focus on open source development, cloud computing, and big data  processing with Java. Zack's twitter handle: @zackshoylev and Freenode nick: zacksh
@@ -24,26 +24,26 @@ For example, when listing database users in openstack-trove (the OpenStack datab
     "users": [
         {
             "databases": [],
-            "host": "%", 
+            "host": "%",
             "name": "dbuser1"
-        }, 
+        },
         {
             "databases": [
                 {
                     "name": "databaseB"
-                }, 
+                },
                 {
                     "name": "databaseC"
                 }
             ],
             "host": "%",
             "name": "dbuser2"
-        }, 
+        },
         {
-            "databases": [], 
+            "databases": [],
             "name": "dbuser3",
             "host": "%"
-        }, 
+        },
         {
             "databases": [
                 {
@@ -57,7 +57,7 @@ For example, when listing database users in openstack-trove (the OpenStack datab
 }
 {% endhighlight %}
 
-To parse the response, jclouds uses [domain classes](https://github.com/jclouds/jclouds/blob/master/apis/openstack-trove/src/main/java/org/jclouds/openstack/trove/v1/domain/User.java) to represent the JSON data returned by the service. The array of "users" is unwrapped into individual User domain objects. Conversely, when creating users, domain objects are transformed into a JSON request body. 
+To parse the response, jclouds uses [domain classes](https://github.com/jclouds/jclouds/blob/master/apis/openstack-trove/src/main/java/org/jclouds/openstack/trove/v1/domain/User.java) to represent the JSON data returned by the service. The array of "users" is unwrapped into individual User domain objects. Conversely, when creating users, domain objects are transformed into a JSON request body.
 
 Because of the relative simplicity of user creation in trove, jclouds developers can use a create method in the features package without having to build an instance of the User class. For example, the developer might use a method such as
 
@@ -92,7 +92,7 @@ Many of the JSON attributes in Neutron are optional. GSON's jclouds configuratio
 
 To ensure immutability, users have no access to a constructor or setters, and instead they must instantiate domain objects by using a slightly modified Builder pattern. The builder pattern also provides proper validation and user-friendliness.
 
-Some [simpler classes](https://github.com/jclouds/jclouds-labs-openstack/blob/master/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/domain/AddressPair.java) implement the regular fluent builder pattern. 
+Some [simpler classes](https://github.com/jclouds/jclouds-labs-openstack/blob/master/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/domain/AddressPair.java) implement the regular fluent builder pattern.
 
 In [other cases](https://github.com/jclouds/jclouds-labs-openstack/blob/master/openstack-neutron/src/main/java/org/jclouds/openstack/neutron/v2/features/NetworkApi.java), the same domain class has several different purposes, such as making sure users have different Network-subtype object instances for updating, creating, and listing networks:
 

--- a/_posts/2014-08-11-using-rpc-host-web-tier-apps.markdown
+++ b/_posts/2014-08-11-using-rpc-host-web-tier-apps.markdown
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "Using Rackspace Private Cloud to Host Your Web Tier Applications"
-date: 2014-08-11 14:00
+title: Using Rackspace Private Cloud to Host Your Web Tier Applications
+date: '2014-08-11 14:00'
 comments: true
 author: James Thorne
 published: true
 categories:
-    - RPC
-    - openstack
-    - private-cloud
+  - RPC
+  - openstack
+  - private-cloud
 ---
 
 Last week, I presented a live webinar on [why web tier applications are a good fit for Rackspace Private Cloud](http://youtu.be/mknyC4tccBQ).

--- a/_posts/2014-08-13-the-not-so-sorry-state-of-ssl-in-python.markdown
+++ b/_posts/2014-08-13-the-not-so-sorry-state-of-ssl-in-python.markdown
@@ -1,14 +1,13 @@
 ---
 layout: post
 title: The not-so-sorry state of SSL in Python
-date: 2014-08-13
+date: 2014-08-13T00:00:00.000Z
 comments: true
 author: Alex Gaynor and David Reid
 published: true
 categories:
- - ssl-tls
- - python
- - security
+  - python
+  - security
 ---
 ### Introduction
 TLS and SSL are two critical technologies which underly much of the secure

--- a/_posts/2014-08-20-using-heat-to-install-a-deis-paas-on-rackspace-cloud.md
+++ b/_posts/2014-08-20-using-heat-to-install-a-deis-paas-on-rackspace-cloud.md
@@ -1,17 +1,12 @@
 ---
 layout: post
 title: Using Heat to install a DEIS PAAS on Rackspace Cloud.
-date: 2014-08-16
+date: 2014-08-16T00:00:00.000Z
 comments: true
 author: Paul Czarkowski
 published: true
-categories:
- - heat
- - paas
- - coreos
-bio: |
- Paul Czarkowski is a Systems Engineer working at Rackspace 
- on the Solum Project.
+categories: []
+bio: "Paul Czarkowski is a Systems Engineer working at Rackspace \non the Solum Project.\n"
 ---
 ### Introduction
 Platform As A Service (PAAS) is an important topic right now. [Docker](http://docker.io)

--- a/_posts/2014-08-21-austin-ladies-hackathon.md
+++ b/_posts/2014-08-21-austin-ladies-hackathon.md
@@ -1,16 +1,12 @@
 ---
 layout: post
-title: "Austin Ladies Hackathon"
-date: 2014-08-21 23:59
+title: Austin Ladies Hackathon
+date: '2014-08-21 23:59'
 comments: true
 author: Anne Gentle
 published: true
 categories:
-    - women-in-tech
-    - austin-ladies
-    - mobile
-    - developers
-    - hackathon
+  - developers
 ---
 
 Austin Ladies Hackathon

--- a/_posts/2014-08-21-austin-ladies-hackathon.md
+++ b/_posts/2014-08-21-austin-ladies-hackathon.md
@@ -9,39 +9,39 @@ categories:
     - women-in-tech
     - austin-ladies
     - mobile
-    - developer
+    - developers
     - hackathon
 ---
 
 Austin Ladies Hackathon
 =======================
 
-This weekend was a blast, hacking with all women at Rackspace, and wow were the projects impressive. Here's how it went. 
+This weekend was a blast, hacking with all women at Rackspace, and wow were the projects impressive. Here's how it went.
 
 Friday night we gathered at a restaurant, the Flying Saucer, to meet each other and start to form teams. I’d guessimate that 20 of the 30 participants showed up. I helped out by facilitating discussions for people to find teams, and I spent a lot of the night talking to complete newcomers about what a hackathon is like, what to expect, and especially how to learn at one. We also recruited for the upcoming NoSQL Mobile App Challenge (http://rackspacemobile.challengepost.com/).
 
 <!-- more -->
 
-Saturday the teams gathered at Rackspace Austin to start coding. I believe most of the teams formed by the end of Friday night. The beginners were distributed quite evenly on the teams, and five teams took on five challenges. On Saturday one of the Ruby teams had one person who couldn’t get the dev environment running, so we all did “phone a friend” to get her going again. Many thanks to my Developer Relations teammate for returning my call. We got her sorted out. Pro tip: don’t name a folder "Workout Buddies – Austin Ladies Hack!” if you expect to do bundle install or bundle exec in it. 
+Saturday the teams gathered at Rackspace Austin to start coding. I believe most of the teams formed by the end of Friday night. The beginners were distributed quite evenly on the teams, and five teams took on five challenges. On Saturday one of the Ruby teams had one person who couldn’t get the dev environment running, so we all did “phone a friend” to get her going again. Many thanks to my Developer Relations teammate for returning my call. We got her sorted out. Pro tip: don’t name a folder "Workout Buddies – Austin Ladies Hack!” if you expect to do bundle install or bundle exec in it.
 
 Four of the five teams wanted to know how to deploy their app, so I did a 10-minute talk about deployment, demonstrating local dev > staging >production with the developer.rackspace.com Github repo and walking through 12 Factors. It was really well received, though I don’t feel like I know enough about the topic deeply (like ansible, fabric, and so on). I did mention horizontal scaling and shooting cloud servers in the head, which was quite memorable for my young son Nathan in the front row.
 
 My brain was so excited about the possibilities for all the teams' presentations next day. So Saturday night I researched how to populate a Google Spreadsheet with published KVM data from a Google Map but was thwarted in my POC Python code by OAuth2.
 
-Sunday the teams came back to code for about another three hours prior to presentations. Here's a great group photo of everyone from Sunday. 
+Sunday the teams came back to code for about another three hours prior to presentations. Here's a great group photo of everyone from Sunday.
 
 {% img austin-ladies-hackathon/group-photo-austin-ladies-hack.png %}
 
 Our judges were Austin site leader Bill Blackstone, new Racker and Austin Pyladies founder Sara Safavi, and Chief Scientist at Artemis Capital, Katrina Riehl. They had their work cut out for them as these teams made completely demo-able apps and great presentations. With each presentation, I thought, well, that one’s going to win. Every team shone. There wasn’t much of a competitive vibe, but we did end up with these placings and prizes provided by Ebay and NumFocus:
 
-1. Texas Women’s Clinic Finder web app – Shows a map with color-coded pointers for women’s health offerings at http://twcf.webflow.com/. 
+1. Texas Women’s Clinic Finder web app – Shows a map with color-coded pointers for women’s health offerings at http://twcf.webflow.com/.
 
-2. Water Your Wallet: Kivy mobile app — enter a Texas city, then enter a plant name and number of plants you have in your garden or landscape, and get the cost of watering it. 
+2. Water Your Wallet: Kivy mobile app — enter a Texas city, then enter a plant name and number of plants you have in your garden or landscape, and get the cost of watering it.
 
-3. Workout Buddies: Ruby/Sinatra web app – enter your workout interests, find people also interested as well as upcoming events. Hooked up with Facebook and worked really hard on Google + integration. 
+3. Workout Buddies: Ruby/Sinatra web app – enter your workout interests, find people also interested as well as upcoming events. Hooked up with Facebook and worked really hard on Google + integration.
 
 Special recognition for best Python app: SkillCluster – Have a primary programming language but want to know what other technologies are in high demand in job postings? Enter the primary language then the app looks for clusters of secondary skills like frameworks or co-present programming languages. Guess what co-existed the most with Python? You’ll never guess. XML.
 
-Symptom Tracker: Android app – choose a body part then enter symptoms you or a family member is experiencing (such as a child or elderly person) on your mobile divide so you can take a listing and record to the doctor and look for trends. 
+Symptom Tracker: Android app – choose a body part then enter symptoms you or a family member is experiencing (such as a child or elderly person) on your mobile divide so you can take a listing and record to the doctor and look for trends.
 
-Their empathy for users was incredible and a huge reason why I think we need women developers all over the place! I was inspired by the energy and technical acumen in the room. 
+Their empathy for users was incredible and a huge reason why I think we need women developers all over the place! I was inspired by the energy and technical acumen in the room.

--- a/_posts/2014-08-29-using-rpc-software-dev-lifecycle.markdown
+++ b/_posts/2014-08-29-using-rpc-software-dev-lifecycle.markdown
@@ -1,16 +1,20 @@
 ---
 layout: post
-title: "Using Rackspace Private Cloud to Support Your Software Development Lifecycle"
-date: 2014-08-29 16:00
+title: Using Rackspace Private Cloud to Support Your Software Development Lifecycle
+date: '2014-08-29 16:00'
 comments: true
 author: James Thorne
 published: true
 categories:
-    - RPC
-    - openstack
-    - private-cloud
-bio: |
- James Thorne is a Sales Engineer at Rackspace focused on working with OpenStack. He is a Texas State University alumnus and former Platform Consultant at Red Hat. James has been working with Linux professionally for the past four years and in his free time even longer. James blogs at thornelabs.net and can be followed on Twitter @jameswthorne.
+  - RPC
+  - openstack
+  - private-cloud
+bio: >
+  James Thorne is a Sales Engineer at Rackspace focused on working with
+  OpenStack. He is a Texas State University alumnus and former Platform
+  Consultant at Red Hat. James has been working with Linux professionally for the
+  past four years and in his free time even longer. James blogs at thornelabs.net
+  and can be followed on Twitter @jameswthorne.
 ---
 
 Last week, I presented a live webinar on [using Rackspace Private Cloud to support your software development lifecycle](http://youtu.be/s9GNgYUpXyU).

--- a/_posts/2014-09-09-create-an-indestructible-blog-with-jekyll.markdown
+++ b/_posts/2014-09-09-create-an-indestructible-blog-with-jekyll.markdown
@@ -1,15 +1,12 @@
 ---
 layout: post
-title:  "Create an indestructible blog with Jekyll, CloudFiles and the PHP SDK"
-date:   2014-01-09 13:00
+title: 'Create an indestructible blog with Jekyll, CloudFiles and the PHP SDK'
+date: '2014-01-09 13:00'
 comments: true
-author:   Jamie Hannaford
+author: Jamie Hannaford
 published: true
 categories:
- - jekyll
- - cloud-files
- - php-sdk
- - php-opencloud
+  - cloud-files
 ---
 
 Everyone wants a blog these days, but no-one really wants all the collateral that comes with it: servers, databases, language runtimes, firewalls and load balancers, DNS management, deployment and automation. I've heard about all these mystical characters on the scene, like Vagrant, Docker and Capistrano, but what do they actually do? Sure I can spend hours reading docs but I have more important things to do -- like stare aimlessly at Reddit threads and check out new doge memes.

--- a/_posts/2014-09-10-running-coreos-and-kubernetes.markdown
+++ b/_posts/2014-09-10-running-coreos-and-kubernetes.markdown
@@ -1,22 +1,16 @@
 ---
 layout: post
-title: "Corekube: Running Kubernetes on CoreOS via OpenStack"
-date: 2014-09-10 12:26
+title: 'Corekube: Running Kubernetes on CoreOS via OpenStack'
+date: '2014-09-10 12:26'
 comments: true
 author: Mike Metral
 published: true
 categories:
-- public-cloud
-- cloud-servers
-- OpenStack
-- architecture
-- Docker
-- containers
-- CoreOS
-bio:
- Mike Metral is a Solution Architect at Rackspace in the Private Cloud R&D
- organization. Mike joined Rackspace in 2012 to help establish OpenStack become the open standard for cloud management.
- You can follow Mike on Twitter @mikemetral and Github as metral.
+  - public-cloud
+  - cloud-servers
+  - OpenStack
+  - Docker
+bio: 'Mike Metral is a Solution Architect at Rackspace in the Private Cloud R&D organization. Mike joined Rackspace in 2012 to help establish OpenStack become the open standard for cloud management. You can follow Mike on Twitter @mikemetral and Github as metral.'
 ---
 
 Docker, CoreOS and Kubernetes are new, emerging technologies that are

--- a/_posts/2014-09-22-big-data-solution-running-on-rpc.md
+++ b/_posts/2014-09-22-big-data-solution-running-on-rpc.md
@@ -1,19 +1,20 @@
 ---
 layout: post
-title: "A Big Data Solution Running On Top of Rackspace Private Cloud"
-date: 2014-09-22 11:00
+title: A Big Data Solution Running On Top of Rackspace Private Cloud
+date: '2014-09-22 11:00'
 comments: true
 author: James Thorne
 published: true
 categories:
-    - RPC
-    - openstack
-    - private-cloud
-    - mongodb
-    - cassandra
-    - hadoop
-bio: |
- James Thorne is a Sales Engineer at Rackspace focused on working with OpenStack. He is a Texas State University alumnus and former Platform Consultant at Red Hat. James has been working with Linux professionally for the past four years and in his free time even longer. James blogs at thornelabs.net and can be followed on Twitter @jameswthorne.
+  - RPC
+  - openstack
+  - private-cloud
+bio: >
+  James Thorne is a Sales Engineer at Rackspace focused on working with
+  OpenStack. He is a Texas State University alumnus and former Platform
+  Consultant at Red Hat. James has been working with Linux professionally for the
+  past four years and in his free time even longer. James blogs at thornelabs.net
+  and can be followed on Twitter @jameswthorne.
 ---
 
 Two weeks ago, I presented a live webinar on [a big data solution running on top of Rackspace Private Cloud](http://youtu.be/V55gzeBxmwE).

--- a/_posts/2014-09-23-serving-pentago-exploring-hpc-data-using-node.md
+++ b/_posts/2014-09-23-serving-pentago-exploring-hpc-data-using-node.md
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Serving Pentago: Exploring HPC data using Node.js on Rackspace"
-date: 2014-09-23 00:01
+title: 'Serving Pentago: Exploring HPC data using Node.js on Rackspace'
+date: '2014-09-23 00:01'
 comments: true
 author: Geoffrey Irving
 published: true
 categories:
-    - Pentago
-    - HPC
-    - nodejs
-bio:
-    Geoffrey Irving is a founder at the new interactive programming startup Eddy Systems (http://eddy.systems). Previously, he worked at Pixar, D. E. Shaw Research, Weta Digital, and Otherlab doing high performance computing, computational physics, and computer graphics. He has degrees in mathematics and computer science from Caltech and Stanford, and received film credits on Ratatouille, Wall-E, Up, and Tintin.
+  - nodejs
+bio: 'Geoffrey Irving is a founder at the new interactive programming startup Eddy Systems (http://eddy.systems). Previously, he worked at Pixar, D. E. Shaw Research, Weta Digital, and Otherlab doing high performance computing, computational physics, and computer graphics. He has degrees in mathematics and computer science from Caltech and Stanford, and received film credits on Ratatouille, Wall-E, Up, and Tintin.'
 ---
 
 [Pentago](https://en.wikipedia.org/wiki/Pentago) is a board game designed by

--- a/_posts/2014-09-29-adding-devices-to-an-existing-swift-cluster.markdown
+++ b/_posts/2014-09-29-adding-devices-to-an-existing-swift-cluster.markdown
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Adding devices into an existing Swift cluster"
-date: 2014-09-29 13:46
+title: Adding devices into an existing Swift cluster
+date: '2014-09-29 13:46'
 comments: true
 author: Angela Streeter
 published: true
-categories:
-    - swift
-bio:
-    Angela Streeter is a cloud technology instructor at Rackspace, where she teaches OpenStack in public and private training sessions. Angela and her team spend their time evangelizing OpenStack through training, blogs and contributions. Angela graduated from Texas State University with a BS in computer science and a minor in mathematics. She has worked as a software developer and prior to the training team was a linux systems administrator at Rackspace for the customer support teams. Angela's twitter handle and freenode nick is angelastreeter. Angela blogs at http://streetstack.net.
+categories: []
+bio: "Angela Streeter is a cloud technology instructor at Rackspace, where she teaches OpenStack in public and private training sessions. Angela and her team spend their time evangelizing OpenStack through training, blogs and contributions. Angela graduated from Texas State University with a BS in computer science and a minor in mathematics. She has worked as a software developer and prior to the training team was a linux systems administrator at Rackspace for the customer support teams. Angela's twitter handle and freenode nick is angelastreeter. Angela blogs at http://streetstack.net."
 ---
 
 If you already have an existing Swift cluster and you would like to add additional storage, you can use the swift-ring-builder command on the ring builder files from any server that you have the utility installed on. Once you update the files, you will need to push them out to all the nodes in your cluster.

--- a/_posts/2014-10-17-rubydcamp14.markdown
+++ b/_posts/2014-10-17-rubydcamp14.markdown
@@ -1,16 +1,13 @@
 ---
-layout: post  
-title: "Ruby DCamp 2014"  
-date: 2014-10-17 23:59  
-comments: true  
-author: Don Schenck  
-published: true  
+layout: post
+title: Ruby DCamp 2014
+date: '2014-10-17 23:59'
+comments: true
+author: Don Schenck
+published: true
 categories:
   - Ruby
-  - Open source
-  - Conference
-bio:
-  Don Schenck is a Rackspace OpenStack .NET SDK Developer Advocate. Prior to Rackspace, Don worked across a broad range of industries, from helping pharmaceutical companies track and improve quality to building software to control machines that cut and bend reinforcing steel. Most recently, Don was involved in mobile and kiosk application development. Find him on twitter @DonSchenck
+bio: 'Don Schenck is a Rackspace OpenStack .NET SDK Developer Advocate. Prior to Rackspace, Don worked across a broad range of industries, from helping pharmaceutical companies track and improve quality to building software to control machines that cut and bend reinforcing steel. Most recently, Don was involved in mobile and kiosk application development. Find him on twitter @DonSchenck'
 ---
 
 From October 9-12, 2014, I attended the seventh annual Ruby DCamp at Prince William Forest Park at Triangle, Virginia. Rackspace was a Platinum sponsor of the "non conference", which is a collision between Ruby developers and communal living. Without a doubt, a unique combination.

--- a/_posts/2014-10-24-php-opencloud-1-11-0-released.md
+++ b/_posts/2014-10-24-php-opencloud-1-11-0-released.md
@@ -1,20 +1,18 @@
 ---
 layout: post
-title: "php-opencloud 1.11.0 Released"
-date: 2014-10-24 08:00
+title: php-opencloud 1.11.0 Released
+date: '2014-10-24 08:00'
 comments: true
 author: Shaunak Kashyap
 published: true
 categories:
-- php-opencloud
-- php
-- sdk
-- developers
-- openstack
+  - sdk
+  - developers
+  - openstack
 bio: |
- Shaunak Kashyap is a Developer Advocate on the Rackspace Developer Experience
- team. He works primarily on the open-source php-opencloud SDK. You can find
- Shaunak on Twitter @shaunak and Github as ycombinator.
+  Shaunak Kashyap is a Developer Advocate on the Rackspace Developer Experience
+  team. He works primarily on the open-source php-opencloud SDK. You can find
+  Shaunak on Twitter @shaunak and Github as ycombinator.
 ---
 
 Today we are proud to announce the [v1.11.0 release](https://github.com/rackspace/php-opencloud/releases/tag/v1.11.0) of php-opencloud. In the four months since our last minor release, we have added support for the [OpenStack Orchestration service](https://wiki.openstack.org/wiki/Heat), support for [booting a server from a volume](http://docs.openstack.org/user-guide/content/boot_from_volume.html), and several other improvements and bug fixes. Many of these improvements and bug fixes have come from community contributors, which makes this release just that much more special.

--- a/_posts/2014-10-24-php-opencloud-1-11-0-released.md
+++ b/_posts/2014-10-24-php-opencloud-1-11-0-released.md
@@ -9,7 +9,7 @@ categories:
 - php-opencloud
 - php
 - sdk
-- developer
+- developers
 - openstack
 bio: |
  Shaunak Kashyap is a Developer Advocate on the Rackspace Developer Experience

--- a/_posts/2014-10-28-introducing-gophercloud.md
+++ b/_posts/2014-10-28-introducing-gophercloud.md
@@ -1,14 +1,12 @@
 ---
-layout: post  
-title: "Introducing Gophercloud: an OpenStack SDK for Go"  
-date: 2014-10-28 11:45  
-comments: true  
-author: Developer Experience Team  
-published: true  
+layout: post
+title: 'Introducing Gophercloud: an OpenStack SDK for Go'
+date: '2014-10-28 11:45'
+comments: true
+author: Developer Experience Team
+published: true
 categories:
-  - golang
   - sdk
-  - gophercloud
 ---
 
 As part of our ongoing mission to serve developers, we are proud to announce the initial public release of [Gophercloud](https://github.com/rackspace/gophercloud/). Gophercloud is a [Go](http://golang.org) OpenStack&trade;-first SDK with Rackspace support. What that means is Rackspace and OpenStack&trade; users can seamlessly integrate it into their existing applications, and users of other Openstack-based clouds can extend it to work with theirs.

--- a/_posts/2014-10-31-docker-kubernetes-gophercloud.md
+++ b/_posts/2014-10-31-docker-kubernetes-gophercloud.md
@@ -1,14 +1,12 @@
 ---
-layout: post  
-title: "Docker host management, Kubernetes Rackspace binary install, and Gophercloud 1.0"  
-date: 2014-10-31 10:45  
-comments: true  
-author: Developer Experience Team  
-published: true  
+layout: post
+title: 'Docker host management, Kubernetes Rackspace binary install, and Gophercloud 1.0'
+date: '2014-10-31 10:45'
+comments: true
+author: Developer Experience Team
+published: true
 categories:
   - docker
-  - gophercloud
-  - rackspace
 ---
 ### Docker Host Management
 

--- a/_posts/2014-11-03-jenkins-workers-using-jclouds-on-rpc.markdown
+++ b/_posts/2014-11-03-jenkins-workers-using-jclouds-on-rpc.markdown
@@ -1,18 +1,24 @@
 ---
 layout: post
-title: "Create Jenkins Workers Using jclouds on RPC"
-date: 2014-11-03 16:00
+title: Create Jenkins Workers Using jclouds on RPC
+date: '2014-11-03 16:00'
 comments: true
 author: Everett Toews
 published: true
 categories:
-    - RPC
-    - openstack
-    - private-cloud
-    - jclouds
-bio: |
- Everett is a Developer Advocate at Rackspace making OpenStack and the Rackspace Cloud easy to use for developers and operators. Sometimes developer, sometimes advocate, and sometimes operator. He's a committer and PMC on Apache jclouds, and co-author of the OpenStack Operations Guide from O'Reilly. He loves spending time with his family. If it's calm outside, they launch rockets. If it's windy, they fly kites.
- Follow him on Twitter @everett_toews.
+  - RPC
+  - openstack
+  - private-cloud
+  - jclouds
+bio: >
+  Everett is a Developer Advocate at Rackspace making OpenStack and the Rackspace
+  Cloud easy to use for developers and operators. Sometimes developer, sometimes
+  advocate, and sometimes operator. He's a committer and PMC on Apache jclouds,
+  and co-author of the OpenStack Operations Guide from O'Reilly. He loves
+  spending time with his family. If it's calm outside, they launch rockets. If
+  it's windy, they fly kites.
+
+  Follow him on Twitter @everett_toews.
 ---
 
 This blog post will show you how to dynamically create Jenkins workers on demand using jclouds on Rackspace Private Cloud. You can use those workers to run your build jobs and increase the capacity of your continuous integration pipeline by parallelizing builds. All powered by OpenStack.

--- a/_posts/2014-11-03-using-heat-with-rackspace-private-cloud.md
+++ b/_posts/2014-11-03-using-heat-with-rackspace-private-cloud.md
@@ -1,16 +1,14 @@
 ---
 layout: post
-title: "Using Heat with Rackspace Private Cloud"
-date: 2014-11-03 23:59
+title: Using Heat with Rackspace Private Cloud
+date: '2014-11-03 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
- - rackspace-private-cloud
- - Heat
- - OpenStack
-bio:
- Walter Bentley is a Rackspace Private Cloud Solutions Architect with a background in Production Systems Administration and Solutions Architecture. In the past, always being the requester, consumer and advisor to companies to use technologies such as OpenStack, now promoter of OpenStack technology and Cloud educator. Twitter @djstayflypro
+  - rackspace-private-cloud
+  - OpenStack
+bio: 'Walter Bentley is a Rackspace Private Cloud Solutions Architect with a background in Production Systems Administration and Solutions Architecture. In the past, always being the requester, consumer and advisor to companies to use technologies such as OpenStack, now promoter of OpenStack technology and Cloud educator. Twitter @djstayflypro'
 ---
 
 One of the **HOT**est new projects released within the previous release of OpenStack is the Heat project.  Described as a main line project part of the OpenStack Orchestration program because Heat alone is not the complete orchestration capability being developed by the community, my gut tells me we have more projects based on orchestration coming soon.  Setting some base ground work on what Heat provides capability wise is important.  This is covered in two quick topics, what is orchestration and what is a stack?

--- a/_posts/2014-11-06-configure-keystone-apache.md
+++ b/_posts/2014-11-06-configure-keystone-apache.md
@@ -1,16 +1,14 @@
 ---
 layout: post
-title: "Configure Keystone to Utilize Apache"
-date: 2014-11-06 17:20
+title: Configure Keystone to Utilize Apache
+date: '2014-11-06 17:20'
 comments: true
 author: Matt Dorn
 published: true
 categories:
- - OpenStack
- - apache
- - python
-bio:
- Matt Dorn is a Cloud Technology Instructor with Rackspace focused on helping IT teams around the world build private clouds with OpenStack. You can find his blog at http://www.madorn.com/
+  - OpenStack
+  - python
+bio: 'Matt Dorn is a Cloud Technology Instructor with Rackspace focused on helping IT teams around the world build private clouds with OpenStack. You can find his blog at http://www.madorn.com/'
 ---
 
 Keystone and many current OpenStack API components run in an [Eventlet](http://eventlet.net/) based http server.  Eventlet is designed to perform well in networked environments and handles everything in a single thread.

--- a/_posts/2014-11-06-configure-keystone-apache.md
+++ b/_posts/2014-11-06-configure-keystone-apache.md
@@ -7,7 +7,6 @@ author: Matt Dorn
 published: true
 categories:
  - OpenStack
- - openstack-keystone
  - apache
  - python
 bio:

--- a/_posts/2014-11-07-openstack-orchestration-in-depth-part-1-introduction-to-heat.md
+++ b/_posts/2014-11-07-openstack-orchestration-in-depth-part-1-introduction-to-heat.md
@@ -8,7 +8,6 @@ published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-  - openstack-heat
 bio:
   Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
   He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at

--- a/_posts/2014-11-07-openstack-orchestration-in-depth-part-1-introduction-to-heat.md
+++ b/_posts/2014-11-07-openstack-orchestration-in-depth-part-1-introduction-to-heat.md
@@ -1,20 +1,14 @@
 ---
 layout: post
-title: "OpenStack Orchestration In Depth, Part I: Introduction to Heat"
-date: 2014-11-07 07:15
+title: 'OpenStack Orchestration In Depth, Part I: Introduction to Heat'
+date: '2014-11-07 07:15'
 comments: true
 author: Miguel Grinberg
 published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-bio:
-  Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
-  He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at
-  http://blog.miguelgrinberg.com, where he writes about a variety of topics including web
-  development, robotics, photography and the occasional movie review. Miguel works as a
-  Software Developer with the Rackspace Private Cloud team. He lives in Portland,
-  Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter.
+bio: "Miguel Grinberg is a software engineer with a background in web technologies and REST APIs. He is the author of the book \"Flask Web Development\" from O'Reilly Media, and has a blog at http://blog.miguelgrinberg.com, where he writes about a variety of topics including web development, robotics, photography and the occasional movie review. Miguel works as a Software Developer with the Rackspace Private Cloud team. He lives in Portland, Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter."
 ---
 
 With this article I begin a series of hands-on developer oriented blog posts that

--- a/_posts/2014-11-14-openstack-orchestration-in-depth-part-2-single-instance-deployments.md
+++ b/_posts/2014-11-14-openstack-orchestration-in-depth-part-2-single-instance-deployments.md
@@ -8,7 +8,6 @@ published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-  - openstack-heat
 bio:
   Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
   He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at

--- a/_posts/2014-11-14-openstack-orchestration-in-depth-part-2-single-instance-deployments.md
+++ b/_posts/2014-11-14-openstack-orchestration-in-depth-part-2-single-instance-deployments.md
@@ -1,20 +1,14 @@
 ---
 layout: post
-title: "OpenStack Orchestration In Depth, Part II: Single Instance Deployments"
-date: 2014-11-14 07:15
+title: 'OpenStack Orchestration In Depth, Part II: Single Instance Deployments'
+date: '2014-11-14 07:15'
 comments: true
 author: Miguel Grinberg
 published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-bio:
-  Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
-  He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at
-  http://blog.miguelgrinberg.com, where he writes about a variety of topics including web
-  development, robotics, photography and the occasional movie review. Miguel works as a
-  Software Developer with the Rackspace Private Cloud team. He lives in Portland,
-  Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter.
+bio: "Miguel Grinberg is a software engineer with a background in web technologies and REST APIs. He is the author of the book \"Flask Web Development\" from O'Reilly Media, and has a blog at http://blog.miguelgrinberg.com, where he writes about a variety of topics including web development, robotics, photography and the occasional movie review. Miguel works as a Software Developer with the Rackspace Private Cloud team. He lives in Portland, Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter."
 ---
 
 Welcome to the second part of my series on OpenStack orchestration with Heat. In the [previous article](/blog/openstack-orchestration-in-depth-part-1-introduction-to-heat) I gave you an introduction to Heat orchestration. All the examples I showed you were simple and not terribly useful, as they were only intended to introduce the structure of the HOT (Heat Orchestration Template) syntax.

--- a/_posts/2014-11-17-automate-creating-rackspace-cloud-load-balancer.md
+++ b/_posts/2014-11-17-automate-creating-rackspace-cloud-load-balancer.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Automate creating Rackspace Cloud Load Balancer"
-date: 2014-11-17 23:59
+title: Automate creating Rackspace Cloud Load Balancer
+date: '2014-11-17 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - Ansible
+  - Ansible
 ---
 
 Recently I embarked on a customer project where they wanted to dynamically create (automate) a complete application stack, starting from the base server provisioning all the way up to the application deployment.  One piece of the puzzle, previously seen as something to be done manually but now considered as part of the stack, is load balancers and any configurations related to load balancing.  

--- a/_posts/2014-11-17-automate-creating-rackspace-cloud-load-balancer.md
+++ b/_posts/2014-11-17-automate-creating-rackspace-cloud-load-balancer.md
@@ -6,8 +6,7 @@ comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-public-cloud
-    - Ansible 
+    - Ansible
 ---
 
 Recently I embarked on a customer project where they wanted to dynamically create (automate) a complete application stack, starting from the base server provisioning all the way up to the application deployment.  One piece of the puzzle, previously seen as something to be done manually but now considered as part of the stack, is load balancers and any configurations related to load balancing.  
@@ -19,7 +18,7 @@ There was an earlier blog post from Jesse Keating on [Rolling Deployments with A
    * Create a Cloud Load Balancer
    * Create a DNS subdomain associated with the load balancer
    * Enable SSL Termination and add an SSL certificate
-   
+
 
 Currently, my favorite automation tool is Ansible, so the following discussion uses Ansible and Rackspace Cloud-specific modules to demonstrate using Load Balancers.
 

--- a/_posts/2014-11-17-deploying-rackspace-private-cloud-v9-with-ansible.md
+++ b/_posts/2014-11-17-deploying-rackspace-private-cloud-v9-with-ansible.md
@@ -1,18 +1,15 @@
 ---
 layout: post
-title: "Deploying Rackspace Private Cloud v9.0 with Ansible"
-date: 2014-11-17 23:59
+title: Deploying Rackspace Private Cloud v9.0 with Ansible
+date: '2014-11-17 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-private-cloud
-    - v9.0
-    - Ansible
-    - OpenStack
-    - Icehouse
-bio:
-  Walter Bentley – Rackspace Private Cloud Solutions Architect – Walter is a new Racker with a diverse background in Production Systems Administration and Solutions Architecture. He brings over 15 years of experience across numerous industries such as Online Marketing, Financial, Insurance, Aviation, Food Industry and Education. In the past, always being the requestor, consumer and advisor to companies to use technologies such as OpenStack, now promoter of OpenStack technology and Cloud educator. You can find him on Twitter as @djstayflypro
+  - rackspace-private-cloud
+  - Ansible
+  - OpenStack
+bio: 'Walter Bentley – Rackspace Private Cloud Solutions Architect – Walter is a new Racker with a diverse background in Production Systems Administration and Solutions Architecture. He brings over 15 years of experience across numerous industries such as Online Marketing, Financial, Insurance, Aviation, Food Industry and Education. In the past, always being the requestor, consumer and advisor to companies to use technologies such as OpenStack, now promoter of OpenStack technology and Cloud educator. You can find him on Twitter as @djstayflypro'
 ---
 
 In the newest release of the Rackspace Private Cloud (RPC v9.0), we made changes to the reference architecture for improved stability. These changes included a different approach for deploying the cloud internally, which may also interest anyone looking into running the Rackspace private cloud.  The decision to use Ansible going forward was based on two major thoughts: ease of deployment and flexible configuration.  Ansible made it very easy for Rackspace to simplify the overall deployment and give users the ability to reconfigure the deployment as needed to fit their environments.  Are you familiar with Ansible?  If yes…skip the next paragraph and if not, please read on.

--- a/_posts/2014-11-25-openstack-orchestration-in-depth-part-3-multi-instance-deployments.md
+++ b/_posts/2014-11-25-openstack-orchestration-in-depth-part-3-multi-instance-deployments.md
@@ -8,7 +8,6 @@ published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-  - openstack-heat
 bio:
   Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
   He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at

--- a/_posts/2014-11-25-openstack-orchestration-in-depth-part-3-multi-instance-deployments.md
+++ b/_posts/2014-11-25-openstack-orchestration-in-depth-part-3-multi-instance-deployments.md
@@ -1,20 +1,14 @@
 ---
 layout: post
-title: "OpenStack Orchestration In Depth, Part III: Multi-Instance Deployments"
-date: 2014-11-21 07:15
+title: 'OpenStack Orchestration In Depth, Part III: Multi-Instance Deployments'
+date: '2014-11-21 07:15'
 comments: true
 author: Miguel Grinberg
 published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-bio:
-  Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
-  He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at
-  http://blog.miguelgrinberg.com, where he writes about a variety of topics including web
-  development, robotics, photography and the occasional movie review. Miguel works as a
-  Software Developer with the Rackspace Private Cloud team. He lives in Portland,
-  Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter.
+bio: "Miguel Grinberg is a software engineer with a background in web technologies and REST APIs. He is the author of the book \"Flask Web Development\" from O'Reilly Media, and has a blog at http://blog.miguelgrinberg.com, where he writes about a variety of topics including web development, robotics, photography and the occasional movie review. Miguel works as a Software Developer with the Rackspace Private Cloud team. He lives in Portland, Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter."
 ---
 
 This is the third article in my series on OpenStack orchestration with Heat. In [Part 1](/blog/openstack-orchestration-in-depth-part-1-introduction-to-heat), I introduced the HOT template syntax, and then in [Part 2](/blog/openstack-orchestration-in-depth-part-2-single-instance-deployments/), I showed you some of the techniques Heat offers to orchestrate the deployment of applications that run entirely within a single compute instance.

--- a/_posts/2015-01-06-automate-deploying-rackspace-cloud-monitoring-agent.md
+++ b/_posts/2015-01-06-automate-deploying-rackspace-cloud-monitoring-agent.md
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Automate deploying Rackspace Cloud Monitoring agent"
-date: 2015-01-06 23:59
+title: Automate deploying Rackspace Cloud Monitoring agent
+date: '2015-01-06 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-cloud-monitoring
-    - Ansible
+  - Ansible
 ---
 
 So after being asked to do what I considered to be a easy thing, I soon realized that it was not :(. Rather it was easy to do, just not easy to automate doing it. Figured others could benefit from my discoveries. Before getting started, please note these instructions are for RHEL, Fedora and CentOS. Some minor modifications would be needed to accommodate Ubuntu, but the same concepts apply.

--- a/_posts/2015-01-27-using-docker-machine-to-deploy-your-docker-containers-on-rackspace.md
+++ b/_posts/2015-01-27-using-docker-machine-to-deploy-your-docker-containers-on-rackspace.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Using Docker Machine to run your Docker Containers in Rackspace"
-date: 2015-01-27 08:00
+title: Using Docker Machine to run your Docker Containers in Rackspace
+date: '2015-01-27 08:00'
 comments: true
 author: Simon J
 published: true
 categories:
-    - Orchestration
-    - docker
+  - Orchestration
+  - docker
 ---
 
 ## Background

--- a/_posts/2015-01-28-how-did-we-serve-more-than-20000-ipython-notebooks-for-nature.md
+++ b/_posts/2015-01-28-how-did-we-serve-more-than-20000-ipython-notebooks-for-nature.md
@@ -6,7 +6,7 @@ comments: true
 author: Kyle Kelley
 published: true
 categories:
-    - IPython
+    - Python
     - Science
     - Data Science
     - Docker
@@ -59,6 +59,6 @@ This bit us in a couple ways. In order to scale across hosts we'd need to put th
 
 ## Closing up
 
-In the end we ended up serving more than 20,000 notebook servers and counting. 
+In the end we ended up serving more than 20,000 notebook servers and counting.
 
 We love IPython notebooks, the overall architecture that has been built out here, and hope to keep supporting Open Source projects do interesting things on the internet in a way that benefits community, technology, and the whole ecosystem.

--- a/_posts/2015-01-28-how-did-we-serve-more-than-20000-ipython-notebooks-for-nature.md
+++ b/_posts/2015-01-28-how-did-we-serve-more-than-20000-ipython-notebooks-for-nature.md
@@ -1,18 +1,13 @@
 ---
 layout: post
-title: "How did we serve more than 20,000 IPython notebooks for Nature readers?"
-date: 2015-01-28
+title: 'How did we serve more than 20,000 IPython notebooks for Nature readers?'
+date: 2015-01-28T00:00:00.000Z
 comments: true
 author: Kyle Kelley
 published: true
 categories:
-    - Python
-    - Science
-    - Data Science
-    - Docker
-    - tmpnb
-    - Jupyter
-    - Ephemeral
+  - Python
+  - Docker
 ---
 
 The IPython/Jupyter notebook is a wonderful environment for computations, prose, plots, and interactive widgets that you can share with collaborators. People use the notebook [all](http://blog.quantopian.com/quantopian-research-your-backtesting-data-meets-ipython-notebook/) [over](http://nbviewer.ipython.org/github/GoogleCloudPlatform/ipython-soccer-predictions/blob/master/predict/wc-final.ipynb) [the](https://github.com/facebook/iTorch) [place](http://nbviewer.ipython.org/url/norvig.com/ipython/TSPv3.ipynb) across [many varied languages](https://github.com/ipython/ipython/wiki/IPython-kernels-for-other-languages). It gets used by [data scientists](http://nbviewer.ipython.org/gist/wrobstory/1eb8cb704a52d18b9ee8/Up%20and%20Down%20PyData%202014.ipynb), researchers, analysts, developers, and people in between.

--- a/_posts/2015-02-10-openstack-orchestration-in-depth-part-4-scaling.md
+++ b/_posts/2015-02-10-openstack-orchestration-in-depth-part-4-scaling.md
@@ -8,7 +8,6 @@ published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-  - openstack-heat
 bio:
   Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
   He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at

--- a/_posts/2015-02-10-openstack-orchestration-in-depth-part-4-scaling.md
+++ b/_posts/2015-02-10-openstack-orchestration-in-depth-part-4-scaling.md
@@ -1,20 +1,14 @@
 ---
 layout: post
-title: "OpenStack Orchestration In Depth, Part IV: Scaling"
-date: 2015-02-10 07:15
+title: 'OpenStack Orchestration In Depth, Part IV: Scaling'
+date: '2015-02-10 07:15'
 comments: true
 author: Miguel Grinberg
 published: true
 categories:
   - rackspace-private-cloud
   - Orchestration
-bio:
-  Miguel Grinberg is a software engineer with a background in web technologies and REST APIs.
-  He is the author of the book "Flask Web Development" from O'Reilly Media, and has a blog at
-  http://blog.miguelgrinberg.com, where he writes about a variety of topics including web
-  development, robotics, photography and the occasional movie review. Miguel works as a
-  Software Developer with the Rackspace Private Cloud team. He lives in Portland,
-  Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter.
+bio: "Miguel Grinberg is a software engineer with a background in web technologies and REST APIs. He is the author of the book \"Flask Web Development\" from O'Reilly Media, and has a blog at http://blog.miguelgrinberg.com, where he writes about a variety of topics including web development, robotics, photography and the occasional movie review. Miguel works as a Software Developer with the Rackspace Private Cloud team. He lives in Portland, Oregon with his wife, four kids, two dogs and a cat. Follow @miguelgrinberg on Twitter."
 ---
 
 This is the fourth and last article in my series on OpenStack orchestration with Heat. In the previous articles, I gave you a gentle [introduction to Heat](/blog/openstack-orchestration-in-depth-part-1-introduction-to-heat), and then I showed you some techniques to orchestrate the deployment of [single](/blog/openstack-orchestration-in-depth-part-2-single-instance-deployments/) and [multiple](/blog/openstack-orchestration-in-depth-part-3-multi-instance-deployments/) instance applications on the cloud, all done with generic and reusable components.

--- a/_posts/2015-02-12-Introducing-PoshStack-the-PowerShell-client-for-OpenStack.md
+++ b/_posts/2015-02-12-Introducing-PoshStack-the-PowerShell-client-for-OpenStack.md
@@ -1,19 +1,15 @@
 ---
 layout: post
-title: "Introducing PoshStack, the PowerShell client for OpenStack"
-date: 2015-02-12 12:15
+title: 'Introducing PoshStack, the PowerShell client for OpenStack'
+date: '2015-02-12 12:15'
 comments: true
 author: Don Schenck
 published: true
 categories:
   - OpenStack
-  - Windows
-  - PowerShell
   - DevOps
   - Automation
-  - Scripting
-bio:
-  Don Schenck is a Developer Advocate with the Developer Experience team at Rackspace, with a main focus on .NET technologies. Follow @DonSchenck on Twitter.
+bio: 'Don Schenck is a Developer Advocate with the Developer Experience team at Rackspace, with a main focus on .NET technologies. Follow @DonSchenck on Twitter.'
 ---
 
 ##Here's PoshStack

--- a/_posts/2015-02-14-i-loved-pytennessee.md
+++ b/_posts/2015-02-14-i-loved-pytennessee.md
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "I Loved PyTennessee 2015"
-date: 2015-02-14
+title: I Loved PyTennessee 2015
+date: 2015-02-14T00:00:00.000Z
 comments: true
 author: Kyle Kelley
 published: true
 categories:
-    - Python
-    - Tennessee
-    - PyTennessee
-    - Conferences
+  - Python
 ---
 
 [Python Tennessee](https://www.pytennessee.org/) was a wonderfully put together conference with a great variety of speakers.

--- a/_posts/2015-02-16-monitoring-hadoop-with-rackspace-cloud-services.md
+++ b/_posts/2015-02-16-monitoring-hadoop-with-rackspace-cloud-services.md
@@ -1,21 +1,13 @@
 ---
 layout: post
-title: "Monitoring Hadoop with Rackspace Cloud services — managing partial failure"
-date: 2015-02-16 10:00
+title: Monitoring Hadoop with Rackspace Cloud services — managing partial failure
+date: '2015-02-16 10:00'
 comments: true
 author: Dave Beckett
 published: true
-categories:
-  - rackspace-cloud-monitoring
+categories: []
 bio:
-  - Dave Beckett is a software engineer with a background in multiple
-    data and web metadata systems (from RDF to CSV) working in
-    the Rackspace Data Platform group.  He spends most of his
-    time tending the Hadoop cluster and writing Python to automate
-    that.  Dave lives in San Francisco with his wife and in his spare
-    time codes on his free software projects such as
-    Redland RDF http://librdf.org/
-    More details at http://www.dajobe.org/ and https://github.com/dajobe/
+  - 'Dave Beckett is a software engineer with a background in multiple data and web metadata systems (from RDF to CSV) working in the Rackspace Data Platform group.  He spends most of his time tending the Hadoop cluster and writing Python to automate that.  Dave lives in San Francisco with his wife and in his spare time codes on his free software projects such as Redland RDF http://librdf.org/ More details at http://www.dajobe.org/ and https://github.com/dajobe/'
 ---
 
 Hadoop is constructed from a large set of servers (or nodes) so to

--- a/_posts/2015-02-17-mysql-backup-to-rackspace-cloud-files.md
+++ b/_posts/2015-02-17-mysql-backup-to-rackspace-cloud-files.md
@@ -6,9 +6,8 @@ comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-public-cloud
     - rackspace-cloud-files
-    - Ansible 
+    - Ansible
 ---
 
 While this blog post may seem trivial on the surface, it does pack some very interesting information on how very flexible the Rackspace Cloud Files product can be.  While executing another customer project, the age old question of: “Where are we going to put the database backups?” was raised.  Back in the day this question only really had one solution.  In the current age of the cloud, you have a few options.  Since I like to live life on the edge…I raised my hand and said Cloud Files.
@@ -31,12 +30,12 @@ Let’s get started!
 Clone the repo below to pull down the roles you will need.  Consider this a working example that you can later alter for your specific needs.
 
 	$ git clone --recursive https://github.com/wbentley15/rax-ansible-cf.git
-	
+
 #####Step #2: Examine roles and populate variables
 
 Take a look at the roles and familiarize yourself with the steps. Find below all the variables for which you will need to supply values. The variables are located in the group_vars directory within the localhost file:
 
-	dbuser: database user with admin privileges 
+	dbuser: database user with admin privileges
 	dbpass: database user password
 	raxcontainer:  Rackspace Cloud Files container name
 	raxkey:  Rackspace API key

--- a/_posts/2015-02-17-mysql-backup-to-rackspace-cloud-files.md
+++ b/_posts/2015-02-17-mysql-backup-to-rackspace-cloud-files.md
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "MySQL backup to Rackspace Cloud Files"
-date: 2015-02-17 23:59
+title: MySQL backup to Rackspace Cloud Files
+date: '2015-02-17 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-cloud-files
-    - Ansible
+  - Ansible
 ---
 
 While this blog post may seem trivial on the surface, it does pack some very interesting information on how very flexible the Rackspace Cloud Files product can be.  While executing another customer project, the age old question of: “Where are we going to put the database backups?” was raised.  Back in the day this question only really had one solution.  In the current age of the cloud, you have a few options.  Since I like to live life on the edge…I raised my hand and said Cloud Files.

--- a/_posts/2015-02-28-cloud-servers-reboot-info.md
+++ b/_posts/2015-02-28-cloud-servers-reboot-info.md
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "cs-reboot-info: A tool to assist with upcoming maintenance"
-date: 2015-02-28 13:00
+title: 'cs-reboot-info: A tool to assist with upcoming maintenance'
+date: '2015-02-28 13:00'
 comments: true
 author: Developer Experience Team
 published: true
-categories:
-    - devex
-    - utils
+categories: []
 ---
 **Important Update: Oct 17, 2015**
 

--- a/_posts/2015-03-02-evolution-of-openstack-from-infancy-to-enterprise.md
+++ b/_posts/2015-03-02-evolution-of-openstack-from-infancy-to-enterprise.md
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Evolution of OpenStack - From Infancy to Enterprise"
-date: 2015-03-02 23:59
+title: Evolution of OpenStack - From Infancy to Enterprise
+date: '2015-03-02 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - openstack
-    - openstack-for-enterprises 
+  - openstack
 ---
 
 Recently I had the pleasure of hosting a webinar covering the Evolution of OpenStack.  No matter how many times I review the history of OpenStack, I manage to learn something new.  Just the idea that multiple companies, with distinct unique ideas can come together to make what I consider to be a super platform is amazing.  Whether you think OpenStack is ready for prime time or not, it is hard to deny the power and disruptive nature it has in the current cloud market.  

--- a/_posts/2015-03-12-mongodb-3.0-getting-started.md
+++ b/_posts/2015-03-12-mongodb-3.0-getting-started.md
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Getting acquainted with MongoDB 3.0"
-date: 2015-03-12 23:59
+title: Getting acquainted with MongoDB 3.0
+date: '2015-03-12 23:59'
 comments: true
 author: Kenny Gorman
 categories:
-    - MongoDB
-    - Ansible
+  - Ansible
 ---
 
 MongoDB Inc just released what is arguably the most important change to the MongoDB database in its short history.

--- a/_posts/2015-03-19-learning-to-code-at-clojurebridge.md
+++ b/_posts/2015-03-19-learning-to-code-at-clojurebridge.md
@@ -1,15 +1,21 @@
 ---
 layout: post
 title: Learning to Code at ClojureBridge
-date: 2015-03-19 14:00:00+00:00
+date: 2015-03-19T14:00:00.000Z
 comments: true
 author: Everett Toews
 slug: clojurebridge
 published: true
 categories: []
-bio: |
- Everett is a Developer Advocate at Rackspace making OpenStack and the Rackspace Cloud easy to use for developers and operators. Sometimes developer, sometimes advocate, and sometimes operator. He's a committer and PMC on Apache jclouds, and co-author of the OpenStack Operations Guide from O'Reilly. He loves spending time with his family. If it's calm outside, they launch rockets. If it's windy, they fly kites.
- Follow him on Twitter @everett_toews.
+bio: >
+  Everett is a Developer Advocate at Rackspace making OpenStack and the Rackspace
+  Cloud easy to use for developers and operators. Sometimes developer, sometimes
+  advocate, and sometimes operator. He's a committer and PMC on Apache jclouds,
+  and co-author of the OpenStack Operations Guide from O'Reilly. He loves
+  spending time with his family. If it's calm outside, they launch rockets. If
+  it's windy, they fly kites.
+
+  Follow him on Twitter @everett_toews.
 ---
 
 {% img right 2015-03-19-clojure-bridge/clojurebridge.png "ClojureBridge" %}[ClojureBridge](http://www.clojurebridge.org/) aims to increase diversity within the Clojure community by offering free, beginner-friendly Clojure programming workshops for women. On March 13-14, 2015 we held a ClojureBridge event at the Rackspace office in Austin, TX. It was put on by an amazing group of organizers to foster the adoption of Clojure by women in technology.

--- a/_posts/2015-03-19-learning-to-code-at-clojurebridge.md
+++ b/_posts/2015-03-19-learning-to-code-at-clojurebridge.md
@@ -6,6 +6,7 @@ comments: true
 author: Everett Toews
 slug: clojurebridge
 published: true
+categories: []
 bio: |
  Everett is a Developer Advocate at Rackspace making OpenStack and the Rackspace Cloud easy to use for developers and operators. Sometimes developer, sometimes advocate, and sometimes operator. He's a committer and PMC on Apache jclouds, and co-author of the OpenStack Operations Guide from O'Reilly. He loves spending time with his family. If it's calm outside, they launch rockets. If it's windy, they fly kites.
  Follow him on Twitter @everett_toews.

--- a/_posts/2015-03-24-deploying-jupyterhub-for-education.md
+++ b/_posts/2015-03-24-deploying-jupyterhub-for-education.md
@@ -8,7 +8,6 @@ published: true
 categories:
     - python
     - docker
-    - ipython
     - jupyter
     - education
 ---

--- a/_posts/2015-03-24-deploying-jupyterhub-for-education.md
+++ b/_posts/2015-03-24-deploying-jupyterhub-for-education.md
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Deploying JupyterHub for Education"
-date: 2015-03-24 23:59
+title: Deploying JupyterHub for Education
+date: '2015-03-24 23:59'
 comments: true
 author: Jessica Hamrick
 published: true
 categories:
-    - python
-    - docker
-    - jupyter
-    - education
+  - python
+  - docker
 ---
 
 As a PhD student at UC Berkeley, my duties involve some amount of teaching; so, this semester (Spring 2015), as well as last spring, I have been a teaching assistant for a class taught by my advisor, [Tom Griffiths](http://cocosci.berkeley.edu/tom/). The class, called Computational Models of Cognition (COGSCI 131), aims to introduce students to computational models of human behavior. The problem sets are a mixture of simple programming assignments—usually requiring students to implement pieces of different models—and written answers, in which students report and interpret the results of their code.

--- a/_posts/2015-04-07-rackspace-at-pycon.md
+++ b/_posts/2015-04-07-rackspace-at-pycon.md
@@ -1,11 +1,10 @@
 ---
 layout: post
-title: "Rackspace at PyCon 2015"
-date: 2015-04-07 10:00
+title: Rackspace at PyCon 2015
+date: '2015-04-07 10:00'
 comments: false
 author: Brian Curtin
-categories:
-    - PyCon
+categories: []
 ---
 
 [PyCon 2015](https://us.pycon.org/2015/), the annual Python conference,

--- a/_posts/2015-04-08-gophercloud-update.markdown
+++ b/_posts/2015-04-08-gophercloud-update.markdown
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Gophercloud Update"
-date: 2015-04-08 10:00
+title: Gophercloud Update
+date: '2015-04-08 10:00'
 comments: true
 author: Jon Perritt
 published: true
 categories:
-- golang
-- gophercloud
-- openstack
-- sdk
+  - openstack
+  - sdk
 ---
 
 ## New Services Supported

--- a/_posts/2015-04-27-ansible-and-docker.markdown
+++ b/_posts/2015-04-27-ansible-and-docker.markdown
@@ -1,13 +1,13 @@
 ---
 layout: post
 title: Ansible and Docker
-date: 2015-04-27 10:00
+date: '2015-04-27 10:00'
 comments: true
 author: Ash Wilson
 published: true
 categories:
-- ansible
-- docker
+  - ansible
+  - docker
 ---
 
 At first glance, [Ansible](http://www.ansible.com/) and [Docker](https://www.docker.com/) seem to be redundant. Both offer solutions to the configuration management problem through very different means, enabling you to reliably and repeatably manage complicated software deployments. While you certainly can use either on its own with great success, using both together can result in a fast, clean deployment process.

--- a/_posts/2015-05-04-backing-up-cinder-volumes-to-swift.md
+++ b/_posts/2015-05-04-backing-up-cinder-volumes-to-swift.md
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Backing Up Cinder Volumes to Swift"
-date: 2015-05-05 09:52
+title: Backing Up Cinder Volumes to Swift
+date: '2015-05-05 09:52'
 comments: true
 author: James Thorne
 published: true
 categories:
-    - openstack
-    - cinder
-    - swift
+  - openstack
 ---
 
 Architecting applications for a cloud environment usually means treating each cloud server as ephemeral. If you destroy the cloud server, the data is destroyed with it. But, you still need a way to persist data. Cloud block storage has typically been that solution. Attach cloud block storage to a cloud server, save your data within that cloud block device, and when/if the cloud server is destroyed, your data persists and can be re-attached to another cloud server.

--- a/_posts/2015-05-11-breaking-down-the-resistance-to-openstack-laying-the-cloud-foundation.md
+++ b/_posts/2015-05-11-breaking-down-the-resistance-to-openstack-laying-the-cloud-foundation.md
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Breaking Down the Resistance to OpenStack: Laying the Cloud Foundation"
-date: 2015-05-11 23:59
+title: 'Breaking Down the Resistance to OpenStack: Laying the Cloud Foundation'
+date: '2015-05-11 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - openstack
-    - openstack-for-enterprises 
+  - openstack
 ---
 
 As the look and feel of the cloud evolves, matures, and hedges toward main stream adoption, the Solution Architects, Developers, and Infrastructure engineers of Enterprises face the challenge to determine what technologies to consume.  Should I go with something that requires vendor licensing? Or should I look to Open Source technologies, such as OpenStack?  Then if you do decide that OpenStack solves for your technology needs, how best could someone layout its pros and cons to their senior leadership.  

--- a/_posts/2015-05-12-Weekly-Security-Link-Dump.md
+++ b/_posts/2015-05-12-Weekly-Security-Link-Dump.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Weekly Security Link Dump (Week of May 11th)"
-date: 2015-05-12 23:59
+title: Weekly Security Link Dump (Week of May 11th)
+date: '2015-05-12 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 Hello! This is the first post in a series that will bring you new and interesting links every week from the perspective of a Rackspace Security Engineer. I try to include links that are useful/interesting to a general audience, so you don't have to be an "uber 1337 h4x0r" to enjoy them. If you have any comments, or if you want to submit a link, feel free to leave a comment or catch me on [Twitter][twitter].

--- a/_posts/2015-05-18-weekly-security-link-dump.md
+++ b/_posts/2015-05-18-weekly-security-link-dump.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Weekly Security Link Dump (Week of May 18th)"
-date: 2015-05-19 23:59
+title: Weekly Security Link Dump (Week of May 18th)
+date: '2015-05-19 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 Welcome to the Weekly Security Link Dump for the week of May 18th! This week, we'll take a look at some new tech, some broken crypto, and a few guides to help you improve the security of your workstation and your product.

--- a/_posts/2015-05-25-this-week-in-information-security.md
+++ b/_posts/2015-05-25-this-week-in-information-security.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "This Week in Information Security (Week of May 25th)"
-date: 2015-05-28 23:59
+title: This Week in Information Security (Week of May 25th)
+date: '2015-05-28 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 This week we have information about the much-talked-about LogJam vulnerability in SSL/TLS, and several other issues that received less attention, but are scarier in my opinion (e.g. the buffer overflow in NetUSB and the DoS vulnerability in IPsec). We take a brief look at some recent vulnerabilities involving race conditions, affecting companies like Facebook, Dropbox, and Starbucks. We also look at some new research from Google about the effectiveness (or lack thereof) in using "security questions" like "what was your first pet's name?" or "what's your favorite kind of food?" (Spoiler: they're terrible in practice). Finally, for our random link of the week we have an opinion piece calling for the death of the PowerPoint, which sounds great, right?!

--- a/_posts/2015-05-29-reviewing-patches-with-os-ansible-deployment.md
+++ b/_posts/2015-05-29-reviewing-patches-with-os-ansible-deployment.md
@@ -9,7 +9,6 @@ categories:
   - ansible
   - openstack
   - rackspace-private-cloud
-  - openstack-glance
 ---
 
 As someone who works daily on libraries that power OpenStack, OpenStack

--- a/_posts/2015-05-29-reviewing-patches-with-os-ansible-deployment.md
+++ b/_posts/2015-05-29-reviewing-patches-with-os-ansible-deployment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: "Using stackforge/os-ansible-deployment to review OpenStack Patches"
-date: 2015-05-29 23:59
+title: Using stackforge/os-ansible-deployment to review OpenStack Patches
+date: '2015-05-29 23:59'
 comments: true
 author: Ian Cordasco
 published: true

--- a/_posts/2015-05-29-ruled-the-stack-and-lived-to-tell-about-it.md
+++ b/_posts/2015-05-29-ruled-the-stack-and-lived-to-tell-about-it.md
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Ruled the Stack and Lived to Tell About It"
-date: 2015-05-29 23:59
+title: Ruled the Stack and Lived to Tell About It
+date: '2015-05-29 23:59'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - openstack
-    - openstack-summit-vancouver
-    - rule the stack
+  - openstack
 ---
 
 Last week I had the privilege to attend the OpenStack Super Bowl, aka the OpenStack Summit, in Vancouver.  It was incredible just to be around so many other folks who also believe strongly in OpenStack.

--- a/_posts/2015-06-01-this-week-in-infosec-jun-1.md
+++ b/_posts/2015-06-01-this-week-in-infosec-jun-1.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "This Week in Information Security (Week of June 1st)"
-date: 2015-06-02 23:59
+title: This Week in Information Security (Week of June 1st)
+date: '2015-06-02 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 This week we have some interesting research on the security of many Docker containers in the official Docker Hub repository, showing that a large number of images are vulnerable to severe exploits like ShellShock and Heartbleed. We also look at some research introducing a new attack vector utilizing novel [steganography][stego] to deliver exploits to the browser using nothing but HTML5 and images. In other news, the NSA's phone metadata snooping program has folded (at least temporarily) following a failure of the Senate to extend the relevant provisions of the USA PATRIOT act that authorized the program.

--- a/_posts/2015-06-09-goodbye-xml.md
+++ b/_posts/2015-06-09-goodbye-xml.md
@@ -1,21 +1,15 @@
 ---
 layout: post
-title: "Goodbye XML!"
-date: 2015-06-09 23:59
+title: 'Goodbye XML!'
+date: '2015-06-09 23:59'
 comments: true
 author: Brian Rosmaita
 published: true
 categories:
-    - OpenStack
-    - Scripting
-    - Cloud Servers
-    - Public Cloud
-bio:
- Brian Rosmaita is a software developer on the Rackspace team that works
- on Cloud Servers and Cloud Images (that's Nova and Glance in OpenStack
- language).  Upstream at OpenStack, he's a driver for the Glance and
- Searchlight teams.  You can find him on Freenode as rosmaita.  Use @br14nr
- if you want to tweet at him.
+  - OpenStack
+  - Cloud Servers
+  - Public Cloud
+bio: "Brian Rosmaita is a software developer on the Rackspace team that works on Cloud Servers and Cloud Images (that's Nova and Glance in OpenStack language).  Upstream at OpenStack, he's a driver for the Glance and Searchlight teams.  You can find him on Freenode as rosmaita.  Use @br14nr if you want to tweet at him."
 ---
 As a developer working in the cloud, you're probably aware that OpenStack
 (and the cloud industry in general) have moved away from supporting XML APIs.

--- a/_posts/2015-06-09-openstack-swift-use-cases-in-rackspace-private-cloud.md
+++ b/_posts/2015-06-09-openstack-swift-use-cases-in-rackspace-private-cloud.md
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "OpenStack Swift Use Cases in Rackspace Private Cloud"
-date: 2015-06-09 14:19
+title: OpenStack Swift Use Cases in Rackspace Private Cloud
+date: '2015-06-09 14:19'
 comments: true
 author: James Thorne
 published: true
 categories:
-    - openstack
-    - swift
-    - rpc
+  - openstack
+  - rpc
 ---
 
 OpenStack Swift is the object storage project within OpenStack. From the [OpenStack Swift documentation](http://docs.openstack.org/developer/swift/), "Swift is a highly available, distributed, eventually consistent object/blob store. Organizations can use Swift to store lots of data efficiently, safely, and cheaply."

--- a/_posts/2015-06-15-this-week-in-infosec-jun-15.md
+++ b/_posts/2015-06-15-this-week-in-infosec-jun-15.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "This Week in Information Security (Week of June 15th)"
-date: 2015-06-15 23:59
+title: This Week in Information Security (Week of June 15th)
+date: '2015-06-15 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 Welcome back to This Week in Information Security! Sorry if you missed us last week, but posts should follow the schedule you're used to going forward. This week, we have news of two high-profile compromises, a few hair-raising hardware/firmware vulnerabilities, tools from DARPA for searching the "deep" and "dark" web, an opinion piece about vulnerability embargoes in open source software, and more. Finally, we wrap up the week with a fun, interactive article from Bloomberg about the meaning of code and the people and culture that produce it.

--- a/_posts/2015-06-17-built-an-app-on-openstack-at-qcon-ny-2015.md
+++ b/_posts/2015-06-17-built-an-app-on-openstack-at-qcon-ny-2015.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "Built an App on OpenStack at QCon NY 2015"
-date: 2015-06-17 14:00
+title: Built an App on OpenStack at QCon NY 2015
+date: '2015-06-17 14:00'
 comments: true
 author: Everett Toews
 published: true
 categories:
-    - openstack
+  - openstack
 ---
 
 <img class="blog-post right" src="{% asset_path 2015-06-17-built-an-app-on-openstack-at-qcon-ny-2015/qcon.png %}"/>Last week I went to [QCon NY](https://qconnewyork.com/) 2015 to be both a student and a teacher in their tutorial track. They follow the standard pattern of having 2 days of tutorials prior to the conference proper. To understand QCon a bit better, here's their mission statement.

--- a/_posts/2015-06-17-docker-coreos-fleet.md
+++ b/_posts/2015-06-17-docker-coreos-fleet.md
@@ -1,14 +1,18 @@
 ---
 layout: post
-title: "Playing with CoreOS, Fleet and Docker"
-date: 2015-06-17 13:00
+title: 'Playing with CoreOS, Fleet and Docker'
+date: '2015-06-17 13:00'
 comments: true
 author: Sri Rajan
-bio: |
-  Sriram (Sri) Rajan is an Principal Engineer at Rackspace and has more than a decade of professional experience working with computer systems, networks, programming and security. Prior to joining Rackspace, Sri worked as a systems programmer at Texas State University, from where he also earned his masters degree in computer science. He studied and lived in the United States for a total of nine years before relocating to the UK for work in 2010.
+bio: >
+  Sriram (Sri) Rajan is an Principal Engineer at Rackspace and has more than
+  a decade of professional experience working with computer systems, networks,
+  programming and security. Prior to joining Rackspace, Sri worked as a systems
+  programmer at Texas State University, from where he also earned his masters
+  degree in computer science. He studied and lived in the United States for
+  a total of nine years before relocating to the UK for work in 2010.
 published: true
 categories:
-  - coreos
   - docker
 ---
 

--- a/_posts/2015-06-22-this-week-in-infosec-jun-22.md
+++ b/_posts/2015-06-22-this-week-in-infosec-jun-22.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "This Week in Information Security (Week of June 22nd)"
-date: 2015-06-23 23:59
+title: This Week in Information Security (Week of June 22nd)
+date: '2015-06-23 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 Welcome to another installment of This Week in Information Security! This week we have news of a critical vulnerability in millions of Samsung phones, a high-profile compromise of the password management tool LastPass, and a new method for stealing encryption keys via radios, without physically touching the machine in question. We also have tutorials about the basics of cryptography and using the Linux command line, and more!

--- a/_posts/2015-07-02-dev-to-deploy-with-docker-machine-and-compose.md
+++ b/_posts/2015-07-02-dev-to-deploy-with-docker-machine-and-compose.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: "From Local Development to Remote Deployment with Docker Machine and Compose"
-date: 2015-07-02 14:00
+title: From Local Development to Remote Deployment with Docker Machine and Compose
+date: '2015-07-02 14:00'
 comments: true
 author: Everett Toews
 published: true

--- a/_posts/2015-07-02-openstack-osad-and-nagios-against-the-world.md
+++ b/_posts/2015-07-02-openstack-osad-and-nagios-against-the-world.md
@@ -1,16 +1,15 @@
 ---
 layout: post
-title: "OpenStack OSAD and Nagios, against the world"
-date: 2015-07-02 13:00
+title: 'OpenStack OSAD and Nagios, against the world'
+date: '2015-07-02 13:00'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-private-cloud
-    - OSAD
-    - OpenStack
-    - Nagios
-    - Ansible
+  - rackspace-private-cloud
+  - OSAD
+  - OpenStack
+  - Ansible
 ---
 
 Through the course of technology, infrastructure and application monitoring have changed positions.  Not so long ago, monitoring was an afterthought when rolling out your new application or standing up your new rack of servers.  More recently, I have observed monitoring to be one of the first considerations, to the point where it is actually in the initial project plan.

--- a/_posts/2015-07-13-openstacknet-1.4-and-beyond.md
+++ b/_posts/2015-07-13-openstacknet-1.4-and-beyond.md
@@ -8,9 +8,8 @@ authorIsRacker: true
 authorAvatar: https://secure.gravatar.com/avatar/8b96f8872eb3f398809daf017ee3a8ab
 published: true
 categories:
-    - OpenStack
-    - OpenStack.NET
-    - CDN
+  - OpenStack
+  - CDN
 ---
 
 [OpenStack.NET 1.4.0](https://github.com/openstacknetsdk/openstack.net/releases/v1.4.0.0) has just been pushed out the door! This release has two things going for it: the release provides support for Content Delivery Networks (CDN), and it heralds some big changes for the future of OpenStack.NET.

--- a/_posts/2015-07-13-openstacknet-1.4-and-beyond.md
+++ b/_posts/2015-07-13-openstacknet-1.4-and-beyond.md
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "OpenStack.NET 1.4 and Beyond"
-date: 2015-07-13 23:59
+title: OpenStack.NET 1.4 and Beyond
+date: '2015-07-13 23:59'
 comments: true
 author: Carolyn Van Slyck
 authorIsRacker: true
-authorAvatar: https://secure.gravatar.com/avatar/8b96f8872eb3f398809daf017ee3a8ab
+authorAvatar: 'https://secure.gravatar.com/avatar/8b96f8872eb3f398809daf017ee3a8ab'
 published: true
 categories:
   - OpenStack
-  - CDN
 ---
 
 [OpenStack.NET 1.4.0](https://github.com/openstacknetsdk/openstack.net/releases/v1.4.0.0) has just been pushed out the door! This release has two things going for it: the release provides support for Content Delivery Networks (CDN), and it heralds some big changes for the future of OpenStack.NET.

--- a/_posts/2015-07-13-this-week-in-infosec-jul-13.md
+++ b/_posts/2015-07-13-this-week-in-infosec-jul-13.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "This Week in Information Security (Week of July 13th)"
-date: 2015-07-13 23:59
+title: This Week in Information Security (Week of July 13th)
+date: '2015-07-13 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 After 2 weeks off, we're back with another week in information security! We'll dive into several high-profile breaches at the Office of Personnel Management (again) and Hacking Team, a malware creator that counts several governments and law enforcement agencies as customers. The Hacking Team breach uncovered a nasty Adobe Flash 0day that they had discovered and not previously reported, which has been seen in live attacks both before and after public disclosure. On a lighter note, we also have some great guides and tools for you this week.

--- a/_posts/2015-07-16-Rackspace-at-OSCON-2015.md
+++ b/_posts/2015-07-16-Rackspace-at-OSCON-2015.md
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "Rackspace at OSCON 2015"
-date: 2015-07-16 13:00
+title: Rackspace at OSCON 2015
+date: '2015-07-16 13:00'
 comments: true
 author: Brian Curtin
 published: true
-categories:
-    - conferences
-    - OSCON
-
+categories: []
 ---
 
 Next week kicks off the 16th [OSCON](http://www.oscon.com/open-source-2015), an annual conference bringing together the free and open source software world, and Rackspace is a proud Silver Sponsor. Starting July 20 and running through July 24, technologists from around the globe descend on Portland, Oregon for a week of tutorials, talks, keynotes, an expo hall, and more, with Rackers taking part in all of it.

--- a/_posts/2015-07-21-operating-your-openstack-cloud-using-ansible.md
+++ b/_posts/2015-07-21-operating-your-openstack-cloud-using-ansible.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: "Operating Your OpenStack Cloud using Ansible"
-date: 2015-07-21 09:00
+title: Operating Your OpenStack Cloud using Ansible
+date: '2015-07-21 09:00'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-private-cloud
-    - OSAD
-    - OpenStack
-    - Ansible
+  - rackspace-private-cloud
+  - OSAD
+  - OpenStack
+  - Ansible
 ---
 
 So you have spent months convincing your leadership to go with OpenStack.  Finally the keys of the cloud are turned over to you as the Cloud Operator, and you then look over at your co-workers and say “now what”.  The next set of phrases normally are something like: Now how do we best administer this cloud?  Cloud is suppose to be easier, right?

--- a/_posts/2015-07-22-repose-ninja-097.md
+++ b/_posts/2015-07-22-repose-ninja-097.md
@@ -12,7 +12,6 @@ published: true
 categories:
     - Repose
     - OpenStack
-    - OpenStack-Keystone
     - API Management
 ---
 

--- a/_posts/2015-07-22-repose-ninja-097.md
+++ b/_posts/2015-07-22-repose-ninja-097.md
@@ -1,18 +1,13 @@
 ---
 layout: post
-title: "Repose Ninja - Hello World"
-date: 2015-07-22 00:00
+title: Repose Ninja - Hello World
+date: '2015-07-22 00:00'
 comments: true
 author: Bill Scheidegger
-bio: Bill is a Software Developer at Rackspace that is currently working on the open source Repose project
-    and has almost two decades of professional experience in Software and Systems design.
-    Prior to joining Rackspace and after eight years of active duty service in the USAF,
-    he worked primarily on Iridium Based Friendly Force Tracking Solutions for the US Military.
+bio: 'Bill is a Software Developer at Rackspace that is currently working on the open source Repose project and has almost two decades of professional experience in Software and Systems design. Prior to joining Rackspace and after eight years of active duty service in the USAF, he worked primarily on Iridium Based Friendly Force Tracking Solutions for the US Military.'
 published: true
 categories:
-    - Repose
-    - OpenStack
-    - API Management
+  - OpenStack
 ---
 
 ![Alt text here]({% asset_path repose_logo.png %})

--- a/_posts/2015-07-24-this-week-in-infosec-jul-20.md
+++ b/_posts/2015-07-24-this-week-in-infosec-jul-20.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "This Week in Information Security (Week of July 20th)"
-date: 2015-07-24 23:59
+title: This Week in Information Security (Week of July 20th)
+date: '2015-07-24 23:59'
 comments: true
 author: Charles Neill
 published: true
 categories:
-    - Security
+  - Security
 ---
 
 Hey, folks! Lots of scary vulnerabilities today affecting Windows, Internet Explorer, OS X, OpenSSH, and WordPress core. Unfortunately, several of them are still unpatched at the time of writing this. We also have some research into remotely hacking cars to do an attacker's bidding over their cellular network, comparisons between security experts and non-experts in security habits and, finally, some research looking at the huge amount of data exposed to the public Internet by outdated MongoDB nodes that don't use authentication. 

--- a/_posts/2015-07-28-install-openstack-from-source.md
+++ b/_posts/2015-07-28-install-openstack-from-source.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Install OpenStack from source"
-date: 2015-07-28 10:26
+title: Install OpenStack from source
+date: '2015-07-28 10:26'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
+  - OpenStack
+  - OSAD
 ---
 
 Installing OpenStack has always been challenging. Due to the complexity and varity of design choices involved in setting up OpenStack, automated installers are rare. For those who need a small but realistic setup, to be used either for development or learning, a manual installation using the desired distribution's packages has been the typical solution. Distribution packages simplify the process, however they come with compromises.

--- a/_posts/2015-07-28-principles-for-a-successful-developer-workshop.md
+++ b/_posts/2015-07-28-principles-for-a-successful-developer-workshop.md
@@ -1,16 +1,19 @@
 ---
 layout: post
-title: "Principles for a Successful Developer Workshop"
-date: 2015-07-28 14:00
+title: Principles for a Successful Developer Workshop
+date: '2015-07-28 14:00'
 comments: true
 author: Everett Toews
 bio: >
-    Everett is a Rackspace Developer Advocate, he's from Canada (I think) and he's a super-nice guy. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sed qui iste non quos, consequuntur nulla est eaque animi adipisci consectetur ipsam perspiciatis harum vitae voluptatibus assumenda eveniet. Unde, dolor, ex.
+  Everett is a Rackspace Developer Advocate, he's from Canada (I think) and he's
+  a super-nice guy. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sed
+  qui iste non quos, consequuntur nulla est eaque animi adipisci consectetur
+  ipsam perspiciatis harum vitae voluptatibus assumenda eveniet. Unde, dolor,
+  ex.
 authorIsRacker: true
-authorAvatar: https://www.gravatar.com/avatar/c1a75adb52f40016a480cee292527895
+authorAvatar: 'https://www.gravatar.com/avatar/c1a75adb52f40016a480cee292527895'
 published: true
-categories:
-  - workshop
+categories: []
 ---
 
 <img class="blog-post right" src="{% asset_path 2015-07-28-principles-for-a-successful-developer-workshop/qcon1.jpg %}"/>Running a successful developer workshop (aka tutorial) is really difficult. I've attended enough workshops that have gone poorly to know that for a fact. Participating in such a workshop can be very frustrating and a huge turn off for whatever technology is being presented. That translates directly into losing developer mindshare. I think we, as an industry, can do a better job of running developer workshops.

--- a/_posts/2015-08-03-install-openstack-from-source2.md
+++ b/_posts/2015-08-03-install-openstack-from-source2.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Install OpenStack from source Part 2"
-date: 2015-08-03 23:59
+title: Install OpenStack from source Part 2
+date: '2015-08-03 23:59'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
+  - OpenStack
+  - OSAD
 ---
 
 In the [first article of this series](https://developer.rackspace.com/blog/install-openstack-from-source/) we started installing OpenStack from source. We installed keystone and populated it with some basic information including a Services project and an admin user for our new OpenStack install. Additionally in an initial script we setup users and directories for the upcoming installs of the Image service (glance), Networking service (neutron), Compute service (nova) and Volume service (cinder). Now, let's continue and install and start the glance process on the controller node.

--- a/_posts/2015-08-04-install-openstack-from-source3.md
+++ b/_posts/2015-08-04-install-openstack-from-source3.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Install OpenStack from source Part 3"
-date: 2015-08-04 23:59
+title: Install OpenStack from source Part 3
+date: '2015-08-04 23:59'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
+  - OpenStack
+  - OSAD
 ---
 
 In  [article one of this series](https://developer.rackspace.com/blog/install-openstack-from-source/) we started installing OpenStack from source, and, in [article two of this series](https://developer.rackspace.com/blog/install-openstack-from-source2/), we continued the process by installing glance and neutron onto the controller node.

--- a/_posts/2015-08-11-install-openstack-from-source4.md
+++ b/_posts/2015-08-11-install-openstack-from-source4.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-date: 2015-08-11 23:59
-title: "Install OpenStack from source Part 4"
+date: '2015-08-11 23:59'
+title: Install OpenStack from source Part 4
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
+  - OpenStack
+  - OSAD
 ---
 
 This is the fourth installment, in a series showing how to install OpenStack from source. In the three previous articles:

--- a/_posts/2015-08-11-introducing-rack-global-cli.md
+++ b/_posts/2015-08-11-introducing-rack-global-cli.md
@@ -1,16 +1,13 @@
 ---
 layout: post
-date: 2015-08-11 23:59
-title: "Introducing rack &ndash; A Rackspace Global Command-Line Interface"
+date: '2015-08-11 23:59'
+title: 'Introducing rack &ndash; A Rackspace Global Command-Line Interface'
 comments: true
 author: Ken Perkins
 authorIsRacker: true
-authorAvatar: https://pbs.twimg.com/profile_images/421780751701401600/0YpuLSd3_400x400.jpeg
+authorAvatar: 'https://pbs.twimg.com/profile_images/421780751701401600/0YpuLSd3_400x400.jpeg'
 published: true
-categories:
-    - Rackspace
-    - tools
-    - command-line
+categories: []
 ---
 
 It's not every day that we get to release a new tool! Awesome Rackers across the company produce tools all the time, but we think today's news stands alone. We're thrilled to announce the first beta release of `rack`, a new [global command-line interface](https://developer.rackspace.com/docs/rack-cli) purpose-built for interacting with the Rackspace cloud.

--- a/_posts/2015-08-13-install-openstack-from-source5.md
+++ b/_posts/2015-08-13-install-openstack-from-source5.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: "Install OpenStack from source Part 5"
-date: 2015-08-13 06:59
+title: Install OpenStack from source Part 5
+date: '2015-08-13 06:59'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
+  - OpenStack
+  - OSAD
 ---
 
 This is the fifth installment in a series of installing OpenStack from source. The four previous articles can be found here:

--- a/_posts/2015-08-19-2015-introducing-rackspace.net.md
+++ b/_posts/2015-08-19-2015-introducing-rackspace.net.md
@@ -8,9 +8,8 @@ authorIsRacker: true
 authorAvatar: https://secure.gravatar.com/avatar/8b96f8872eb3f398809daf017ee3a8ab
 published: true
 categories:
-    - OpenStack
-    - OpenStack.NET
-    - Rackspace.NET
+  - OpenStack
+  - Rackspace.NET
 ---
 
 The Rackspace .NET SDK beta is now available! This is the first step towards improving the .NET

--- a/_posts/2015-08-19-2015-introducing-rackspace.net.md
+++ b/_posts/2015-08-19-2015-introducing-rackspace.net.md
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "Introducing Rackspace.NET"
-date: 2015-08-19
+title: Introducing Rackspace.NET
+date: 2015-08-19T00:00:00.000Z
 comments: true
 author: Carolyn Van Slyck
 authorIsRacker: true
-authorAvatar: https://secure.gravatar.com/avatar/8b96f8872eb3f398809daf017ee3a8ab
+authorAvatar: 'https://secure.gravatar.com/avatar/8b96f8872eb3f398809daf017ee3a8ab'
 published: true
 categories:
   - OpenStack
-  - Rackspace.NET
 ---
 
 The Rackspace .NET SDK beta is now available! This is the first step towards improving the .NET

--- a/_posts/2015-08-19-containers-in-openstack-ecosystem.md
+++ b/_posts/2015-08-19-containers-in-openstack-ecosystem.md
@@ -1,22 +1,16 @@
 ---
 layout: post
-title: "Containers in the OpenStack Ecosystem"
-date: 2015-08-19 12:26
+title: Containers in the OpenStack Ecosystem
+date: '2015-08-19 12:26'
 comments: true
 author: Mike Metral
 published: true
 categories:
-- public-cloud
-- cloud-servers
-- OpenStack
-- Docker
-- containers
-- CoreOS
-- Kubernetes
-bio:
- Mike Metral is a Product Architect at Rackspace in the Private Cloud R&D
- organization currently operating as a subject-matter expert in the field of containers.
- You can follow Mike on Twitter @mikemetral and Github as metral.
+  - public-cloud
+  - cloud-servers
+  - OpenStack
+  - Docker
+bio: 'Mike Metral is a Product Architect at Rackspace in the Private Cloud R&D organization currently operating as a subject-matter expert in the field of containers. You can follow Mike on Twitter @mikemetral and Github as metral.'
 ---
 
 Container technology is evolving at a very rapid pace. The purpose of the

--- a/_posts/2015-08-20-install-openstack-from-source6.md
+++ b/_posts/2015-08-20-install-openstack-from-source6.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-date: 2015-08-20 23:59
+date: '2015-08-20 23:59'
 title: Install OpenStack from source Part 6
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
+  - OpenStack
+  - OSAD
 ---
 
 This is the sixth and final installment in a series demonstrating how to install OpenStack from source. The five previous articles:

--- a/_posts/2015-08-21-jenkins-post-build-plugin-part-1.md
+++ b/_posts/2015-08-21-jenkins-post-build-plugin-part-1.md
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Jenkins Post-build Plugin Part 1"
-date: 2015-08-21 14:00
+title: Jenkins Post-build Plugin Part 1
+date: '2015-08-21 14:00'
 comments: true
 author: Priti Changlani
 published: true
 categories:
-    - jenkins
-    - plugin
+  - jenkins
 ---
 This is the first part of a two-part tutorial series to develop a Jenkins plugin
 (specifically, Jenkins post-build plugin). Jenkins is a very popular continuous-integration tool and with the small amount of (scattered) information present

--- a/_posts/2015-08-24-data-science-baltimore.md
+++ b/_posts/2015-08-24-data-science-baltimore.md
@@ -7,7 +7,6 @@ author: Kenny Gorman
 published: true
 categories:
     - data science
-    - ipython
     - Pandas
     - python
 ---

--- a/_posts/2015-08-24-data-science-baltimore.md
+++ b/_posts/2015-08-24-data-science-baltimore.md
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Data science with Pandas; Baltimore City salary analysis"
-date: 2015-08-26 23:59
+title: Data science with Pandas; Baltimore City salary analysis
+date: '2015-08-26 23:59'
 comments: true
 author: Kenny Gorman
 published: true
 categories:
-    - data science
-    - Pandas
-    - python
+  - python
 ---
 
 Wes McKinney started working on Pandas in 2008. Since then, Pandas has become one of the most popular and useful software components for the data scientist. For good reason; using Python, Pandas and iPython/Jupyter notebooks makes it simple and quick to perform analysis on various datasets.

--- a/_posts/2015-08-28-jenkins-post-build-plugin-part-2.md
+++ b/_posts/2015-08-28-jenkins-post-build-plugin-part-2.md
@@ -1,13 +1,12 @@
 ---
 layout: post
-title: "Jenkins Post-build Plugin Part 2"
-date: 2015-08-28 14:00
+title: Jenkins Post-build Plugin Part 2
+date: '2015-08-28 14:00'
 comments: true
 author: Priti Changlani
 published: true
 categories:
-    - jenkins
-    - plugin
+  - jenkins
 ---
 Welcome to part 2 of Jenkins Post-build Plugin development tutorial. This post talks in detail about the plugin 
 project entities and their interactions with each other. To brush up on the previous post, please visit [Jenkins 

--- a/_posts/2015-08-31-using-querySelector-on-elements.md
+++ b/_posts/2015-08-31-using-querySelector-on-elements.md
@@ -1,15 +1,11 @@
 ---
 layout: post
-title: "Using querySelector and querySelectorAll on Elements"
-date: 2015-08-31 23:59
+title: Using querySelector and querySelectorAll on Elements
+date: '2015-08-31 23:59'
 comments: true
 author: lvh
 published: true
-categories:
-    - Web Development
-    - HTML
-    - JavaScript
-
+categories: []
 ---
 
 Modern browsers have APIs called `querySelector` and `querySelectorAll`. They

--- a/_posts/2015-09-16-keystone-to-keystone-federation-with-openstack-ansible.md
+++ b/_posts/2015-09-16-keystone-to-keystone-federation-with-openstack-ansible.md
@@ -1,15 +1,13 @@
 ---
 layout: post
-title: "Keystone-to-Keystone Federation with the openstack-ansible Project"
-date: 2015-09-16 23:59
+title: Keystone-to-Keystone Federation with the openstack-ansible Project
+date: '2015-09-16 23:59'
 comments: true
 author: Miguel Grinberg
 published: true
 categories:
-    - openstack
-    - keystone
-    - osad
-    - federation
+  - openstack
+  - osad
 ---
 
 Federation support in OpenStack has been greatly improved in the Kilo release,

--- a/_posts/2015-09-21-rpc-and-netapp-hearts-block-storage.md
+++ b/_posts/2015-09-21-rpc-and-netapp-hearts-block-storage.md
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "RPC and NetApp Hearts Block Storage"
-date: 2015-09-21 13:00
+title: RPC and NetApp Hearts Block Storage
+date: '2015-09-21 13:00'
 comments: true
 author: Walter Bentley
 published: true
 categories:
-    - rackspace-private-cloud
-    - NetApp
-    - Cinder
-    - Block Storage
+  - rackspace-private-cloud
 ---
 
 Rackspace Private Cloud (RPC) powered by OpenStack has done a great job incorporating and enabling many of the great capabilities natively found within Cinder.  With RPC, you gain the ability to leverage either Cinder nodes (commodity hardware using ephemeral storage exposing that storage as Block storage to your cloud) or to connect your OpenStack cloud directly to a shared storage solution via Cinder integration drivers.  This is where our friends at NetApp come into play.  Rackspace and NetApp have formed a unique relationship to improve the Cinder shared storage capability within OpenStack.  These two teams worked together to create a repeatable, approved, and tested process to integrate NetApp storage solutions into Rackspace Private Cloud footprints within a Rackspace datacenter or at the customer's datacenter.

--- a/_posts/2015-09-22-engineering-managed-cassandra-with-rackspace-and-dse.md
+++ b/_posts/2015-09-22-engineering-managed-cassandra-with-rackspace-and-dse.md
@@ -1,17 +1,13 @@
 ---
 layout: post
-title: "Engineering Managed Cassandra with Rackspace/DSE"
-date: 2015-09-22 08:00
+title: Engineering Managed Cassandra with Rackspace/DSE
+date: '2015-09-22 08:00'
 comments: true
 author: David Grier
 authorIsRacker: true
-authorAvatar: http://1.gravatar.com/userimage/52111727/971866c998c4e064a3c958aa33c82053
+authorAvatar: 'http://1.gravatar.com/userimage/52111727/971866c998c4e064a3c958aa33c82053'
 published: true
-categories:
-    - Cassandra
-    - Big Data
-    - Datastores
-    - Datastax
+categories: []
 ---
 
 Managing infrastructure and database technology has grown at Rackspace and our list of supported technologies in the data umbrella has grown tremendously.

--- a/_posts/2015-09-24-newly-redesigned-developer-portal.md
+++ b/_posts/2015-09-24-newly-redesigned-developer-portal.md
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "The Newly Redesigned Developer Portal"
-date: 2015-09-24
+title: The Newly Redesigned Developer Portal
+date: 2015-09-24T00:00:00.000Z
 comments: true
 author: Trent Gillaspie
 published: true
-categories:
-    - rackspace
-    - announcements
+categories: []
 ---
 
 You may have noticed our Developer Portal looks different. This portal provides you with everything you need to build powerful, scalable apps using our Software Developer Kits (SDKs), which are built on open-source platforms and take advantage of our extensive APIs. We have redesigned Developer.Rackspace.com.

--- a/_posts/2015-10-01-keystone_horizon_nginx.md
+++ b/_posts/2015-10-01-keystone_horizon_nginx.md
@@ -1,14 +1,13 @@
 ---
 layout: post
 title: Run OpenStack Keystone and Horizon using Nginx
-date: 2015-10-01 00:02
+date: '2015-10-01 00:02'
 comments: true
 author: Phil Hopkins
 published: true
 categories:
-    - OpenStack
-    - OSAD
-    - NGINX
+  - OpenStack
+  - OSAD
 authorIsRacker: true
 ---
 

--- a/_posts/2015-10-01-wsgi-middleware-on-the-jvm.md
+++ b/_posts/2015-10-01-wsgi-middleware-on-the-jvm.md
@@ -1,23 +1,18 @@
 ---
 layout: post
-title: "Repose Ninja - WSGI Middleware On The JVM"
-date: 2015-10-01 00:01
+title: Repose Ninja - WSGI Middleware On The JVM
+date: '2015-10-01 00:01'
 comments: true
 author: Damien Johnson
 bio: >
-  Damien is a software developer at Rackspace that is currently working on
-  the open source Repose project. He graduated from the University of Texas at
-  Austin in December of 2013, and has been delivering fanatical results at
-  Rackspace ever since!
+  Damien is a software developer at Rackspace that is currently working on the
+  open source Repose project. He graduated from the University of Texas at Austin
+  in December of 2013, and has been delivering fanatical results at Rackspace
+  ever since!
 published: true
 categories:
-- Repose
-- API Management
-- WSGI
-- Java
-- Python
-- Jython
-- JVM
+  - Java
+  - Python
 authorIsRacker: true
 ---
 

--- a/_posts/2015-10-19-important-xen-vuln-update.md
+++ b/_posts/2015-10-19-important-xen-vuln-update.md
@@ -1,15 +1,14 @@
 ---
 layout: post
-title: "IMPORTANT NOTICE – First and Next Gen Server Vulnerability - October 17, 2015"
-date: 2015-10-19 18:00
+title: 'IMPORTANT NOTICE – First and Next Gen Server Vulnerability - October 17, 2015'
+date: '2015-10-19 18:00'
 comments: true
 author: Richard Goodwin
 authorIsRacker: true
-authorAvatar: https://en.gravatar.com/userimage/29167240/940ffc87a6b337be4bcc2742604a5106.jpeg
+authorAvatar: 'https://en.gravatar.com/userimage/29167240/940ffc87a6b337be4bcc2742604a5106.jpeg'
 published: true
 categories:
   - Cloud Servers
-  - Tools
 ---
 
 An important notice about a vulnerability that may affect First and Next Gen Cloud Servers has been posted. Please read the comprehensive update at the following link:

--- a/_posts/2015-10-20-trinity-article-I.md
+++ b/_posts/2015-10-20-trinity-article-I.md
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Docker, Elastic Beanstalk and Git: a useful trinity for agile development?"
-date: 2015-10-20 05:00
+title: 'Docker, Elastic Beanstalk and Git: a useful trinity for agile development?'
+date: '2015-10-20 05:00'
 comments: true
 author: Duncan Rutland
 bio: Duncan Rutland is a Sr. Solution Architect at Rackspace within the Fanatical Support for AWS team.
 published: true
 categories:
-- AWS
-- Docker
-- Git
-- Elastic Beanstalk
+  - Docker
 authorIsRacker: true
 ---
 

--- a/_posts/2015-10-22-rackspace-grace-hopper.md
+++ b/_posts/2015-10-22-rackspace-grace-hopper.md
@@ -1,18 +1,14 @@
 ---
 layout: post
-title: "Rackspace Moments from Grace Hopper 2015"
-date: 2015-10-22 00:00
+title: Rackspace Moments from Grace Hopper 2015
+date: '2015-10-22 00:00'
 comments: true
 author: Anne Gentle
-authorAvatar: https://en.gravatar.com/userimage/1298029/6adf532b0824e2fe4cd8feab84f6b98e.jpg
+authorAvatar: 'https://en.gravatar.com/userimage/1298029/6adf532b0824e2fe4cd8feab84f6b98e.jpg'
 bio: Anne Gentle is a Principal Engineer at Rackspace where she serves on the OpenStack Technical Committee and advocates for cloud users.
 published: true
 categories:
-- events
-- Grace Hopper
-- outreach
-- women in technology
-- inclusion
+  - events
 authorIsRacker: true
 ---
 

--- a/_posts/2015-10-26-life-without-devstack-openstack-development-with-osa.md
+++ b/_posts/2015-10-26-life-without-devstack-openstack-development-with-osa.md
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "Life Without DevStack: OpenStack Development With OSA"
-date: 2015-10-26 10:00
+title: 'Life Without DevStack: OpenStack Development With OSA'
+date: '2015-10-26 10:00'
 comments: true
 author: Miguel Grinberg
 published: true
 categories:
-    - openstack
-    - osad
-    - ansible
+  - openstack
+  - osad
+  - ansible
 ---
 
 If you are an OpenStack contributor, you likely rely on DevStack for most of

--- a/_posts/2015-11-03-trinity-article-II.md
+++ b/_posts/2015-11-03-trinity-article-II.md
@@ -1,16 +1,13 @@
 ---
 layout: post
-title: "Docker, Elastic Beanstalk and Git: a useful trinity for agile development? Part II"
-date: 2015-11-03 00:00
+title: 'Docker, Elastic Beanstalk and Git: a useful trinity for agile development? Part II'
+date: '2015-11-03 00:00'
 comments: true
 author: Duncan Rutland
 bio: Duncan Rutland is a Sr. Solution Architect at Rackspace within the Fanatical Support for AWS team.
 published: true
 categories:
-- AWS
-- Docker
-- Git
-- Elastic Beanstalk
+  - Docker
 authorIsRacker: true
 ---
 

--- a/_posts/2015-11-09-building-burstable-dr.md
+++ b/_posts/2015-11-09-building-burstable-dr.md
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Building A Burstable DR"
-date: 2015-11-09 00:00
+title: Building A Burstable DR
+date: '2015-11-09 00:00'
 comments: true
 author: Jonathan Hurley
 published: true
-categories:
-    - Ecommerce
+categories: []
 ---
 
 When it comes to the battle cry of E-Commerce, "we're losing $1m per minute" is the clear

--- a/_posts/2015-11-09-case-for-mongo-db-with-aem.md
+++ b/_posts/2015-11-09-case-for-mongo-db-with-aem.md
@@ -1,13 +1,11 @@
 ---
 layout: post
-title: "A Case for MongoDB with AEM"
-date: 2015-11-09 10:00
+title: A Case for MongoDB with AEM
+date: '2015-11-09 10:00'
 comments: true
 author: Jonathan Hurley
 published: true
-categories:
-    - MongoDB
-    - AEM
+categories: []
 ---
 
 #### What is MongoDB?

--- a/_posts/2015-11-10-rack-orchestration-support.md
+++ b/_posts/2015-11-10-rack-orchestration-support.md
@@ -1,19 +1,15 @@
 ---
 layout: post
-date: 2015-11-10
-title: "Cloud Orchestration now available in rack"
+date: 2015-11-10T00:00:00.000Z
+title: Cloud Orchestration now available in rack
 comments: true
 author: Pratik Mallya
 authorIsRacker: true
-authorAvatar: https://avatars2.githubusercontent.com/u/904679?v=3&s=460
+authorAvatar: 'https://avatars2.githubusercontent.com/u/904679?v=3&s=460'
 published: true
 categories:
-    - Rackspace
-    - tools
-    - command-line
-    - Orchestration
-bio:
-  Pratik Mallya is a Software Developer at Rackspace. He works within the Cloud Orchestration team. He holds an MS from UIUC and BS from BITS Pilani, India.
+  - Orchestration
+bio: 'Pratik Mallya is a Software Developer at Rackspace. He works within the Cloud Orchestration team. He holds an MS from UIUC and BS from BITS Pilani, India.'
 ---
 
 We're excited to announce that Cloud Orchestration is now accessible via [`rack`](https://developer.rackspace.com/docs/rack-cli)!

--- a/_posts/2015-11-11-Delivering-Success-Notifications.md
+++ b/_posts/2015-11-11-Delivering-Success-Notifications.md
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Achieving Success by Successfully Delivering Success Notification"
-date: 2015-11-11 10:00
+title: Achieving Success by Successfully Delivering Success Notification
+date: '2015-11-11 10:00'
 comments: true
 author: Jonathan Hurley
 published: true
-categories:
-    - ecommerce
+categories: []
 ---
 
 ### Defining Success

--- a/_posts/2015-11-11-Delivering-Success-Notifications.md
+++ b/_posts/2015-11-11-Delivering-Success-Notifications.md
@@ -7,33 +7,30 @@ author: Jonathan Hurley
 published: true
 categories:
     - ecommerce
---- 
+---
 
-Defining Success
-----------------
+### Defining Success
 
-For most businesses, "success" can be succinctly defined as "delivering a store and 
-processing customer orders". From a business perspective, that's the exact scope - it's 
+For most businesses, "success" can be succinctly defined as "delivering a store and
+processing customer orders". From a business perspective, that's the exact scope - it's
 how an E-Comm business makes its money.
 
-From Online to Offline
-----------------------
+### From Online to Offline
 
-Although demonstrably enjoyable at holidays, surprises when it comes to product purchases 
-are generally frowned upon. Imagine if, after swiping a credit card at the grocery, all of 
-the bags disappeared and were probably, but not always, teleported to their destination 
-with no indication of which it would be! In essence – Schrödinger’s groceries. To say the 
-least, the novelty would wear thin quickly. This scenario (copyrighted, if technologically 
-feasible at future date) is analogous to accepting an order in an e-comm application, but 
-providing no feedback loop on its status afterward. Those bad old days are long gone, but, 
+Although demonstrably enjoyable at holidays, surprises when it comes to product purchases
+are generally frowned upon. Imagine if, after swiping a credit card at the grocery, all of
+the bags disappeared and were probably, but not always, teleported to their destination
+with no indication of which it would be! In essence – Schrödinger’s groceries. To say the
+least, the novelty would wear thin quickly. This scenario (copyrighted, if technologically
+feasible at future date) is analogous to accepting an order in an e-comm application, but
+providing no feedback loop on its status afterward. Those bad old days are long gone, but,
 in their place, stands a new interaction model - real-time feedback.
 
 <!-- more -->
 
-Perception Beats Time
----------------------
+### Perception Beats Time
 
-The perception of real-time confirmation is functionally the sum of a series of processing 
+The perception of real-time confirmation is functionally the sum of a series of processing
 operations:
 
 1. Time required for fraud evaluation
@@ -41,46 +38,44 @@ operations:
 3. Time required for credit confirmation
 4. Time required to render and deliver confirmation
 
-In general, minimizing the first three are part of any standard performance optimization 
-exercise, if there is such a thing. These are easy to grasp concepts that translate well 
-between technical and business teams, both in terms of discrete numbers (seconds of time) 
+In general, minimizing the first three are part of any standard performance optimization
+exercise, if there is such a thing. These are easy to grasp concepts that translate well
+between technical and business teams, both in terms of discrete numbers (seconds of time)
 and business importance.
 
-The perception of speed, however, is based not on real processing operations but on 
-confidence. If a business had complete trust in each of its customer transactions and had 
-infinite inventory, then simply placing an order would be equivalent to success with the page 
-rendered and delivered immediately. In that model, the delivery time is a function 
-only of page rendering and delivery in the environment as a whole. The necessity of a “trust 
-but verify” world means that the operations must succeed but that actual confirmation 
+The perception of speed, however, is based not on real processing operations but on
+confidence. If a business had complete trust in each of its customer transactions and had
+infinite inventory, then simply placing an order would be equivalent to success with the page
+rendered and delivered immediately. In that model, the delivery time is a function
+only of page rendering and delivery in the environment as a whole. The necessity of a “trust
+but verify” world means that the operations must succeed but that actual confirmation
 need not be dependent on that success.
 
-A Matter Of Distinction
------------------------
+### A Matter Of Distinction
 
 A simplistic example is the difference between two phrases:
 
 1. Your order has been received and is being processed
 1. Your order has been processed and shipped
 
-In the former, there is neither implied delivery nor success but only confirmation that the 
-pertinent details of the order have been captured and handed off to the next step of the 
-pipeline. The distinction may not hold up in court, but, when it comes to the perception of 
+In the former, there is neither implied delivery nor success but only confirmation that the
+pertinent details of the order have been captured and handed off to the next step of the
+pipeline. The distinction may not hold up in court, but, when it comes to the perception of
 performance, the technicality can make all of the difference.
 
-If an application is to not wait on the 3 order conversion dependencies above before 
-providing a notification of capture, then where, when, and how will those tasks take place 
+If an application is to not wait on the 3 order conversion dependencies above before
+providing a notification of capture, then where, when, and how will those tasks take place
 without risking the loss of order data? Enter the message queue (MQ).
 
-Spring Clearing House
----------------------
+### Spring Clearing House
 
-Over simplified, an MQ application is responsible for capturing an order, conceptualized 
-as an encapsulated distinct object, and then holding that order for a period of time before 
-ultimately handing off the order for real processing. Another term that is sometimes used 
-for this dynamic is *clearing house*. It is certainly possible and acceptable for the MQ 
-handoff to take place immediately, or as close as possible, after receiving the order. One 
-benefit that some frameworks achieve by holding orders for a period of time is to permit 
-artificial scheduling so that orders are processed at times of low traffic or in 
+Over simplified, an MQ application is responsible for capturing an order, conceptualized
+as an encapsulated distinct object, and then holding that order for a period of time before
+ultimately handing off the order for real processing. Another term that is sometimes used
+for this dynamic is *clearing house*. It is certainly possible and acceptable for the MQ
+handoff to take place immediately, or as close as possible, after receiving the order. One
+benefit that some frameworks achieve by holding orders for a period of time is to permit
+artificial scheduling so that orders are processed at times of low traffic or in
 conjunction with warehouse operations.
 
 Consider this model:
@@ -88,33 +83,29 @@ Consider this model:
 1. Orders are accepted continuously and in real-time
 1. Warehouses operate on a 3-part schedule rotating with a 60m overlap of shifts
 
-Then, if MQ sends orders to warehouses at the beginning of each overlap, there is a 60m 
-opportunity for a 2-shift focus on orders unprocessed from last shift as well as a 2-shift 
+Then, if MQ sends orders to warehouses at the beginning of each overlap, there is a 60m
+opportunity for a 2-shift focus on orders unprocessed from last shift as well as a 2-shift
 processing capacity for new orders.
 
-The Human Element
------------------
+### The Human Element
 
-In similar fashion to perceived latency or failure in a website, which leads users to 
-refresh or reopen pages, users who do not receive order receipt confirmation are much more 
+In similar fashion to perceived latency or failure in a website, which leads users to
+refresh or reopen pages, users who do not receive order receipt confirmation are much more
 likely to resubmit identical or similar orders, yielding three application challenges:
 
-* **Detection** – programmatically, or through human interaction, detecting and determining 
-when an order with similar properties (e.g. name, shipping address, item SKU, item count) 
+* **Detection** – programmatically, or through human interaction, detecting and determining
+when an order with similar properties (e.g. name, shipping address, item SKU, item count)
 is a duplicate versus an intentionally similar order
-* **Drift** – two orders that are above a threshold of similarity but have drifted (e.g. two 
-identical orders with one additional item in a second). This can occur when a user rethinks 
+* **Drift** – two orders that are above a threshold of similarity but have drifted (e.g. two
+identical orders with one additional item in a second). This can occur when a user rethinks
 a cart item and makes a change between submissions.
-* **Handling** – with identical orders the handling is more straightforward: do not process 
-(or back-process) one of the two (or more) orders. In handling drift, however, intent is 
+* **Handling** – with identical orders the handling is more straightforward: do not process
+(or back-process) one of the two (or more) orders. In handling drift, however, intent is
 significant and is generally determined by time - the most recent order wins.
 
-Message Received
-----------------
+### Message Received
 
-The vast majority of customers will not have advanced degrees in systems analysis, and even 
-those who do are unlikely to be sympathetic to the plight and complexity of managing the 
-confirmation interaction model. The best option is to build a model that does not ask users 
+The vast majority of customers will not have advanced degrees in systems analysis, and even
+those who do are unlikely to be sympathetic to the plight and complexity of managing the
+confirmation interaction model. The best option is to build a model that does not ask users
 to be concerned with its mechanics.
-
-

--- a/_posts/2015-11-13-Ecomm-High-Load.md
+++ b/_posts/2015-11-13-Ecomm-High-Load.md
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "High Load in E-Commerce (pt 1)"
-date: 2015-11-13 10:00
+title: High Load in E-Commerce (pt 1)
+date: '2015-11-13 10:00'
 comments: true
 author: Jonathan Hurley
 published: true
-categories:
-    - ecommerce
+categories: []
 ---
 
 ### The Illusion

--- a/_posts/2015-11-16-Ecomm-Load-Balance.md
+++ b/_posts/2015-11-16-Ecomm-Load-Balance.md
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Load Balancing for E-Commerce (pt 1)"
-date: 2015-11-16 10:00
+title: Load Balancing for E-Commerce (pt 1)
+date: '2015-11-16 10:00'
 comments: true
 author: Jonathan Hurley
 published: true
-categories:
-    - ecommerce
+categories: []
 ---
  
 ### Prelude

--- a/_posts/2015-11-16-Ecomm-Load-Balance.md
+++ b/_posts/2015-11-16-Ecomm-Load-Balance.md
@@ -7,12 +7,11 @@ author: Jonathan Hurley
 published: true
 categories:
     - ecommerce
---- 
+---
  
-Prelude
--------
+### Prelude
 
-Before getting into the nuts and bolts of the load balancing architecture itself, it's 
+Before getting into the nuts and bolts of the load balancing architecture itself, it's
 important to understand the (typical) multiple tiers of an E-Commerce application framework:
 
 1. Firewall (edge)
@@ -21,75 +20,72 @@ important to understand the (typical) multiple tiers of an E-Commerce applicatio
 1. Application Server
 1. Database Server (cluster)
 
-Keep in mind that, top to bottom, the environment will be asymmetrical from a load 
-perspective. For example, a single web server will typically be capable of 2-3x the number 
-of concurrent connections as a single application server; heavily dependent on cache 
-density - higher density will shift more load up into the web tier. Caching will be a 
-subject for a later discussion, but at a glance should account for 80+ percent of content 
-served. With room for variance, the majority of successful architectures achieve this metric 
-and those that struggle tend to miss. This is not to say, of course, that a lower density 
-will necessarily have difficulties. In addition to relocating load away from application 
-servers, a higher cache density opens an opportunity for external services, such as Akamai 
+Keep in mind that, top to bottom, the environment will be asymmetrical from a load
+perspective. For example, a single web server will typically be capable of 2-3x the number
+of concurrent connections as a single application server; heavily dependent on cache
+density - higher density will shift more load up into the web tier. Caching will be a
+subject for a later discussion, but at a glance should account for 80+ percent of content
+served. With room for variance, the majority of successful architectures achieve this metric
+and those that struggle tend to miss. This is not to say, of course, that a lower density
+will necessarily have difficulties. In addition to relocating load away from application
+servers, a higher cache density opens an opportunity for external services, such as Akamai
 CDN, to absorb load ahead of ever reaching the environment.
 
 <!-- more -->
 
-Starting Small
---------------
+### Starting Small
 
-For smaller ecomm architectures it is effective to build 1:1 pipelines from the web tier, 
-such as having one web server for each application server. This opens the option to 
-statically configure connections so that the LTM is a single point of balancing that then 
-cascades down. In addition to being simple to explain and document, this architecture 
-greatly reduces the number of moving parts which especially pays dividends during 
-troubleshooting and monitoring. Deployment simplicity is an additional, often overlooked, 
-benefit that originates in the ability to transparently, and without manual intervention 
+For smaller ecomm architectures it is effective to build 1:1 pipelines from the web tier,
+such as having one web server for each application server. This opens the option to
+statically configure connections so that the LTM is a single point of balancing that then
+cascades down. In addition to being simple to explain and document, this architecture
+greatly reduces the number of moving parts which especially pays dividends during
+troubleshooting and monitoring. Deployment simplicity is an additional, often overlooked,
+benefit that originates in the ability to transparently, and without manual intervention
 at the LTM or FW layer, remove hosts from load by failing LTM health checks.
 
-Exploring Algorithms
---------------------
+### Exploring Algorithms
 
-It is very tempting to explore more intelligent balancing algorithms with ecomm 
-architectures because of the variable nature of session load. A simplified example contrasts 
-two types of sessions - browse vs cart. In the former, a visitor may be requesting numerous, 
-potentially unrelated, pages as they explore the catalog. In a perfect world, that 
-interaction is wholly cached and never traverses as deep as the application servers. The 
-latter session type, however, does require interaction with the application in order to 
-manage the cart and session data. Further, if the cart interaction results in a conversion, 
+It is very tempting to explore more intelligent balancing algorithms with ecomm
+architectures because of the variable nature of session load. A simplified example contrasts
+two types of sessions - browse vs cart. In the former, a visitor may be requesting numerous,
+potentially unrelated, pages as they explore the catalog. In a perfect world, that
+interaction is wholly cached and never traverses as deep as the application servers. The
+latter session type, however, does require interaction with the application in order to
+manage the cart and session data. Further, if the cart interaction results in a conversion,
 then there is further load as order processing, shipping, and revenue tasks are executed.
 
-Not existing in a perfect world, both load models must be accounted for in the application 
-as those server processes will necessarily be carrying some percentage of non-dynamic 
-traffic. This model leads to decision number one - optimize around the likely more critical 
-conversion traffic or focus on the more frequent, lower-impact browse traffic. In the simple 
-1:1 architecture above, this decision is made and implemented from the perspective of the 
-LTM only. Although this simplifies the decision tree by eliminating factors, it also forces 
-an "either / or" proposition for east-west load distribution. A simple example that could 
-occur would be if the LTM implements a round-robin algorithm and, by happenstance, all order 
-conversion sessions are sent to a single web server. This scenario can result in anomalously 
-elevated load for the application server and potentially the web server in that stack. 
-Strictly speaking this is not a problem, provided that a single web and app server can 
-sustain the load of all concurrent orders. Of course, if that is the case, then the 
+Not existing in a perfect world, both load models must be accounted for in the application
+as those server processes will necessarily be carrying some percentage of non-dynamic
+traffic. This model leads to decision number one - optimize around the likely more critical
+conversion traffic or focus on the more frequent, lower-impact browse traffic. In the simple
+1:1 architecture above, this decision is made and implemented from the perspective of the
+LTM only. Although this simplifies the decision tree by eliminating factors, it also forces
+an "either / or" proposition for east-west load distribution. A simple example that could
+occur would be if the LTM implements a round-robin algorithm and, by happenstance, all order
+conversion sessions are sent to a single web server. This scenario can result in anomalously
+elevated load for the application server and potentially the web server in that stack.
+Strictly speaking this is not a problem, provided that a single web and app server can
+sustain the load of all concurrent orders. Of course, if that is the case, then the
 environment is probably over-sized for its requirements.
 
-Although this scenario is not likely, perhaps there is a better way? Perhaps. Algorithms 
-that account for load and/or latency could be an effective solution for this behavior. The 
-primary challenge is that the architecture intentionally abstracts application server load 
-in favor of focus on the web servers; due to the nature of caching, even heavy load against 
-the web servers will likely manifest as lower resource utilization than the respective 
-application servers. This gives the artificial, and potentially incorrect, impression that 
+Although this scenario is not likely, perhaps there is a better way? Perhaps. Algorithms
+that account for load and/or latency could be an effective solution for this behavior. The
+primary challenge is that the architecture intentionally abstracts application server load
+in favor of focus on the web servers; due to the nature of caching, even heavy load against
+the web servers will likely manifest as lower resource utilization than the respective
+application servers. This gives the artificial, and potentially incorrect, impression that
 a given web/app pair are not heavily utilized and could accept additional load.
 
-The Multi-Balance Architecture
-------------------------------
+### The Multi-Balance Architecture
 
-So there's no good way to solve the problem? Well not exactly. At its heart the challenge 
-is one of perception; environmental load balancing needs to account for both web and 
-application tier utilization in order to effectively route traffic. The way that hybris, 
-as well as others, have solved this challenge is to implement load balancing functionality 
-within the web tier. Effectively, this means that the LTM balances across web servers then 
-a second tier, potentially the web servers themselves, balance across the application 
-servers. 
+So there's no good way to solve the problem? Well not exactly. At its heart the challenge
+is one of perception; environmental load balancing needs to account for both web and
+application tier utilization in order to effectively route traffic. The way that hybris,
+as well as others, have solved this challenge is to implement load balancing functionality
+within the web tier. Effectively, this means that the LTM balances across web servers then
+a second tier, potentially the web servers themselves, balance across the application
+servers.
 
 For example:
 
@@ -113,22 +109,22 @@ For example:
       </Proxy>
 ```
 
-This example shows use of the mod_proxy_ajp Apache HTTPd module. The primary alternative is 
-mod_jk for Apache. Without descending into a comparative of modules, for another day, there 
+This example shows use of the mod_proxy_ajp Apache HTTPd module. The primary alternative is
+mod_jk for Apache. Without descending into a comparative of modules, for another day, there
 is a difference and a host of reasons to pick one over another. 
 
 A few important takeaways:
 
-* This is configured by VirtualHost. It is not terribly common, but theoretically possible 
+* This is configured by VirtualHost. It is not terribly common, but theoretically possible
   to configure different pools based on the vHost
 * The BalanceMember configuration works in conceptually similar fashion to any LTM:
   * loadfactor : 0-100 defines load weighting
-  * keepalive : prevent idle sessions from timing out. This can lead to load and 
+  * keepalive : prevent idle sessions from timing out. This can lead to load and
     performance issues and should be tested thoroughly
-  * ping : defines an interval in seconds (socket connection if negative) to determine 
-    up/down of target node 
-  * retry : if the member is in a failed state, then do not recheck for n seconds 
-  * max : maximum number of connections from the MPM pool to be sent to that member 
+  * ping : defines an interval in seconds (socket connection if negative) to determine
+    up/down of target node
+  * retry : if the member is in a failed state, then do not recheck for n seconds
+  * max : maximum number of connections from the MPM pool to be sent to that member
      (note: prefork is always 1)
 * ProxySet
   * lbmethod : specify the load balancer method
@@ -136,82 +132,75 @@ A few important takeaways:
   * bytraffic - weighted traffic bytes
   * bybusyness - pending request balancing
   * timeout : wait n seconds for a member to be available
- 
-In Practice
------------
 
-For a traditional balancing discussion, the focus will tend to be on the algorithm 
-itself, because that is the mechanism driving overall performance and behavior. Referencing 
-the above configuration for hybris, the environment will be controlled by two algorithms: 
-*RR* at the LTM and *BR* at HTTPd. Nothing is inherently incorrect or risky with 
+### In Practice
+
+For a traditional balancing discussion, the focus will tend to be on the algorithm
+itself, because that is the mechanism driving overall performance and behavior. Referencing
+the above configuration for hybris, the environment will be controlled by two algorithms:
+*RR* at the LTM and *BR* at HTTPd. Nothing is inherently incorrect or risky with
 this configuration; however, it does introduce two significant challenges:
 
-1. The debugging surface is much larger because it must now account for asymmetric 
+1. The debugging surface is much larger because it must now account for asymmetric
    north-south as well as east-west load patterns.
 1. Inter-node communication must be solved to avoid roaming load.
 
-*Roaming Load* in this context refers to a situation where one or more hosts, typically 
-application servers, experience inflated load distribution as a by-product of load 
+*Roaming Load* in this context refers to a situation where one or more hosts, typically
+application servers, experience inflated load distribution as a by-product of load
 balancing and neither as a direct result of thread performance nor life cycle.
 
-When an Internet request is accepted by the edge firewall, it is passed to the LTM for 
-balancing. Using an RR algorithm, this request will be forwarded to the next HTTPd pool 
-member in sequence. This is expected to achieve a mostly normalized pattern of load shared 
+When an Internet request is accepted by the edge firewall, it is passed to the LTM for
+balancing. Using an RR algorithm, this request will be forwarded to the next HTTPd pool
+member in sequence. This is expected to achieve a mostly normalized pattern of load shared
 equally between nodes. Each HTTPd thread will use its configured algorithm (and byrequests  
-method) to determine, on the fly, which application server is the best match for its new 
-session. 
+method) to determine, on the fly, which application server is the best match for its new
+session.
 
-When Internet connections follow a pattern where time delay between requests exists, this 
-approach may appear to function effectively. Once larger numbers of concurrent connections 
-begin accessing the environment, however, multiple HTTPd threads will simultaneously 
-determine that a single, or few, application server(s) are the best match. When this happens 
-then all threads will balance the session to that same node, raising load from very low to 
-very high in as little as a few seconds. The affected application server is then unlikely 
-to match again for a period of time, causing new connections to all target a different host. 
-This pattern cycles through the environment until either the first-impacted host again 
-becomes the best match or there are no valid matches.  At that point, requests enter a 
+When Internet connections follow a pattern where time delay between requests exists, this
+approach may appear to function effectively. Once larger numbers of concurrent connections
+begin accessing the environment, however, multiple HTTPd threads will simultaneously
+determine that a single, or few, application server(s) are the best match. When this happens
+then all threads will balance the session to that same node, raising load from very low to
+very high in as little as a few seconds. The affected application server is then unlikely
+to match again for a period of time, causing new connections to all target a different host.
+This pattern cycles through the environment until either the first-impacted host again
+becomes the best match or there are no valid matches.  At that point, requests enter a
 waiting state.
 
-The Solution
-------------
+### The Solution
 
-The bad news is that there isn't really a solution for the debugging surface challenge in 
-number 1 above. Any time that there are multiple balancing tiers, the debug surface is a 
+The bad news is that there isn't really a solution for the debugging surface challenge in
+number 1 above. Any time that there are multiple balancing tiers, the debug surface is a
 challenge.
 
 The good news is that avoiding roaming load can be solved in a few ways:
 
-1. **Single HTTPd** - 
-   If a single HTTPd server can handle the expected load and if ancillary HTTPd servers 
-   are for HA only, then the LTM can be configured with weighted pool members such that 
-   web01 is the preferred server, web02 is second, and so on. This preserves an HA 
-   architecture but avoids a situation where multiple HTTPd nodes are competing for best 
+1. **Single HTTPd** -
+   If a single HTTPd server can handle the expected load and if ancillary HTTPd servers
+   are for HA only, then the LTM can be configured with weighted pool members such that
+   web01 is the preferred server, web02 is second, and so on. This preserves an HA
+   architecture but avoids a situation where multiple HTTPd nodes are competing for best
    match.
-1. **Dual LTM** - 
-   This need not be multiple physical LTMs. Logically placing an LTM inline for 
-   HTTPd-to-application traffic is effectively the same as having a single HTTPd server, so 
+1. **Dual LTM** -
+   This need not be multiple physical LTMs. Logically placing an LTM inline for
+   HTTPd-to-application traffic is effectively the same as having a single HTTPd server, so
    only one algorithm and one control process is determining best match at any given time.
-1. **Multi-Pool Application Servers** - 
-   In the hybris example above, a second HTTPd server could be configured with BalanceMembers 
-   192.168.0.3 and 192.168.0.4. Since pool members do not overlap, there is no way for a 
-   single application server to be targeted by multiple HTTPd servers simultaneously. In 
-   this model, traffic is effectively controlled by the LTM algorithm with the HTTPd 
+1. **Multi-Pool Application Servers** -
+   In the hybris example above, a second HTTPd server could be configured with BalanceMembers
+   192.168.0.3 and 192.168.0.4. Since pool members do not overlap, there is no way for a
+   single application server to be targeted by multiple HTTPd servers simultaneously. In
+   this model, traffic is effectively controlled by the LTM algorithm with the HTTPd
    algorithm functioning as a logical secondary.
-1. **Inter-Process Communication** - 
-   This is the least-commonly implemented solution and requires that each balancing process 
-   in a tier be in communication with every other. For example, when an HTTPd process 
-   identifies an application server as best match, it broadcasts its choice to all other 
-   processes, and those processes respond by not matching that node for a given period of 
+1. **Inter-Process Communication** -
+   This is the least-commonly implemented solution and requires that each balancing process
+   in a tier be in communication with every other. For example, when an HTTPd process
+   identifies an application server as best match, it broadcasts its choice to all other
+   processes, and those processes respond by not matching that node for a given period of
    time.
 
-Conclusion
-----------
+### Conclusion
 
-On the surface, this may appear to be an edge case, however, an investigation of the vast 
-majority of ecomm environments reveals this, or similar, gaps. Whether or not these gaps 
-ever impact customer traffic is a product of the business model, load patterns, and 
+On the surface, this may appear to be an edge case, however, an investigation of the vast
+majority of ecomm environments reveals this, or similar, gaps. Whether or not these gaps
+ever impact customer traffic is a product of the business model, load patterns, and
 application thread performance - a matter of *when* not *if*.
-
-
-
-

--- a/_posts/2015-11-18-JVM-Importance-of-Sizing.md
+++ b/_posts/2015-11-18-JVM-Importance-of-Sizing.md
@@ -7,33 +7,32 @@ author: Jonathan Hurley
 published: true
 categories:
     - Ecommerce
---- 
+---
 
-In the good old days the measure of a programmer was efficiency - how much functionality 
-could be packed into how much space. Languages like *C* keep code close to the machine 
-and require close attention to, and strong understanding of, machine operation for 
+In the good old days the measure of a programmer was efficiency - how much functionality
+could be packed into how much space. Languages like *C* keep code close to the machine
+and require close attention to, and strong understanding of, machine operation for
 performance and code execution.
 
-Much like with the catapult, new methods have come along for launching higher-delivery 
-projectiles at high speeds, but, when it comes to hurling a VW beetle the length of a 
-football field, sometimes the old ways are still the best. The importance of efficiency in 
-code has been maligned, and largely obfuscated, by modern delivery mechanisms; however, its 
+Much like with the catapult, new methods have come along for launching higher-delivery
+projectiles at high speeds, but, when it comes to hurling a VW beetle the length of a
+football field, sometimes the old ways are still the best. The importance of efficiency in
+code has been maligned, and largely obfuscated, by modern delivery mechanisms; however, its
 effect remains critical to the performance of complex large-scale applications.
 
 <!-- more -->
  
-How to crash efficiently
-------------------------
+### How to crash efficiently
 
-Languages that execute code via a virtualization layer (like Java uses the Java 
-Virtual Machine (JVM)) bring a host of risks and benefits to the table. One of these soft 
-features is the additional abstraction from actual machine execution that is inherent in 
-the architecture. Among other uses, this provides the programmer, or friendly neighborhood 
+Languages that execute code via a virtualization layer (like Java uses the Java
+Virtual Machine (JVM)) bring a host of risks and benefits to the table. One of these soft
+features is the additional abstraction from actual machine execution that is inherent in
+the architecture. Among other uses, this provides the programmer, or friendly neighborhood
 SysOp, a protective buffer from crashing the parent host.
 
 Note: The following code samples illustrate possible problems, so don't *really* run them!
 
-Executing the following C code on a Linux system wold give you a new appreciation of  the 
+Executing the following C code on a Linux system wold give you a new appreciation of  the
 power and responsibility of direct access to buffers, for example:
 
 ```
@@ -46,8 +45,8 @@ power and responsibility of direct access to buffers, for example:
   }
 ```
 
-So a JVM will never crash? Five minutes of creative development will demonstrate otherwise! 
-The following Java code can result in the marvelously familiar out-of-memory errors and 
+So a JVM will never crash? Five minutes of creative development will demonstrate otherwise!
+The following Java code can result in the marvelously familiar out-of-memory errors and
 inevitable interruption:
 
 ```
@@ -62,7 +61,7 @@ inevitable interruption:
   }
 ```
 
-So a JVM will never crash the OS? It may take closer to 7 minutes, but also not true. See 
+So a JVM will never crash the OS? It may take closer to 7 minutes, but also not true. See
 the following Java Code example:
 
 ```
@@ -75,69 +74,65 @@ public class BadDay {
 }
 ```
 
-If both models can bring down a server, then is there a real difference? Yes and no – the 
-difference is really a product of programmer habits, methodology, and soft education, 
+If both models can bring down a server, then is there a real difference? Yes and no – the
+difference is really a product of programmer habits, methodology, and soft education,
 rather than of the architecture or capabilities of one language over another.
  
-Habits
-------
+### Habits
 
-Programmers are lazy (sorry, programmers). It’s the guiding tenant of everyone who enters 
-the technology ecosystem. If finding an easier way wasn’t the goal, then why spend 1m 
+Programmers are lazy (sorry, programmers). It’s the guiding tenant of everyone who enters
+the technology ecosystem. If finding an easier way wasn’t the goal, then why spend 1m
 man-hours building a software mousetrap?
 
-Consider the Uber application. Fundamentally, it operates under the principle that it’s too 
-complicated, or time consuming, to find a driving service, and that riders and drivers 
-can be connected via a simple interface. The outcome is that lazy riders, almost certainly 
+Consider the Uber application. Fundamentally, it operates under the principle that it’s too
+complicated, or time consuming, to find a driving service, and that riders and drivers
+can be connected via a simple interface. The outcome is that lazy riders, almost certainly
 including its programmers, expend less effort in accomplishing A-to-B.
 
-So it’s a good thing? It certainly can be, but the habit doesn’t stop at entrepreneurial 
+So it’s a good thing? It certainly can be, but the habit doesn’t stop at entrepreneurial
 chauffeur services.
 
-Cogitate on the purpose of garbage collection (GC) in programming languages. Well, useless 
-objects accumulate in memory and have to be cleaned up. That's common sense. No question, 
-but compare garbage collection in native C to Java, and it becomes rapidly apparent that the 
-more modern, Java found a lazy way to accomplish A-to-B. Programmers not being required to 
-contemplate and implement garbage collection has saved countless man-hours. However, another 
-outcome also entered the picture – programmers started to not care about “how”. So what, 
+Cogitate on the purpose of garbage collection (GC) in programming languages. Well, useless
+objects accumulate in memory and have to be cleaned up. That's common sense. No question,
+but compare garbage collection in native C to Java, and it becomes rapidly apparent that the
+more modern, Java found a lazy way to accomplish A-to-B. Programmers not being required to
+contemplate and implement garbage collection has saved countless man-hours. However, another
+outcome also entered the picture – programmers started to not care about “how”. So what,
 the JVM takes care of GC already, right?
  
-Methodology
------------
+### Methodology
 
-Whether paid by lines of code (in a programmer-perfect world), project delivery cost, 
-delivery timeline, or any other number of metrics, every programmer is developing code 
-against a specific requirement target. Unless coding the shutter control algorithm for 
-Discovery’s camera system, operational efficiency and execution footprint are not overly 
-likely to be at the top of the list of requirements. That’s not inherently wrong. 
-Businesses have different priorities, and modern computing systems have moved mountains to 
-reduce the importance of efficiency. The upshot is the *write code that works* approach to 
-projects and a focus on results. That being said, a program that creates 10% more objects 
+Whether paid by lines of code (in a programmer-perfect world), project delivery cost,
+delivery timeline, or any other number of metrics, every programmer is developing code
+against a specific requirement target. Unless coding the shutter control algorithm for
+Discovery’s camera system, operational efficiency and execution footprint are not overly
+likely to be at the top of the list of requirements. That’s not inherently wrong.
+Businesses have different priorities, and modern computing systems have moved mountains to
+reduce the importance of efficiency. The upshot is the *write code that works* approach to
+projects and a focus on results. That being said, a program that creates 10% more objects
 to accomplish the same operation is likely to result in less efficient GC. 
 
-Soft Education
---------------
+### Soft Education
 
-One of the most significant shifts in software programming over the past decade or two is 
-the integrated development environment (IDE). From syntax highlighting to tab completion, 
-these powerful tools help developers to be better at being lazy as well as reducing time 
-to delivery. Both are very important in a results-first approach. Another critical 
+One of the most significant shifts in software programming over the past decade or two is
+the integrated development environment (IDE). From syntax highlighting to tab completion,
+these powerful tools help developers to be better at being lazy as well as reducing time
+to delivery. Both are very important in a results-first approach. Another critical
 side-feature of the IDE is the increased ease with which large project teams can collaborate.
 
-Collaboration – that’s definitely a good thing, isn’t it? When it comes to programming 
-security systems for an island-bound dinosaur park, collaboration certainly helps to reduce 
-the dependency on a single developer. Unfortunately, fluid collaboration also carries a 
+Collaboration – that’s definitely a good thing, isn’t it? When it comes to programming
+security systems for an island-bound dinosaur park, collaboration certainly helps to reduce
+the dependency on a single developer. Unfortunately, fluid collaboration also carries a
 significant risk – obfuscation.
 
-In object-oriented programming (OOP), the tools of collaboration rise to the surface with 
-ease - one widget object needs to combine with another widget object to create a 
-super-widget object. Everyone wants a super-widget, after all, so what’s the problem? 
-Provided that the two widgets are able to communicate, there is really no need for either 
-development team to wonder as to how the respective sub-programs actually work, nor at 
+In object-oriented programming (OOP), the tools of collaboration rise to the surface with
+ease - one widget object needs to combine with another widget object to create a
+super-widget object. Everyone wants a super-widget, after all, so what’s the problem?
+Provided that the two widgets are able to communicate, there is really no need for either
+development team to wonder as to how the respective sub-programs actually work, nor at
 their efficiency, but a chain is only as strong as its weakest link.
  
-What does any of this have to do with JVM sizing?
--------------------------------------------------
+### What does any of this have to do with JVM sizing?
 
 The logical size of a JVM is a combination of several metrics, including the following:
 
@@ -147,94 +142,91 @@ The logical size of a JVM is a combination of several metrics, including the fol
 * *External Operations*
 * *Garbage Collection*
 
-One of this author’s most common arguments opportunities for collaborative discussion 
+One of this author’s most common arguments opportunities for collaborative discussion
 involves the phrase “max heap is ___ MB, so why does the system keep running out of memory?”
-The truth is that there is no single setting, nor value, that enforces a maximum JVM size, 
+The truth is that there is no single setting, nor value, that enforces a maximum JVM size,
 other than the combined physical memory and swap space of its host OS. So could any JVM  
-runaway and take all of the system memory? No, but it’s most common for JVM application 
+runaway and take all of the system memory? No, but it’s most common for JVM application
 servers to be sized based on the expected JVM size plus a small amount for the OS overhead.
 
-What’s the point of setting the 2 dozen flags for the JVM if none of them control the 
-memory footprint? The purpose is to set boundaries, similar to having multiple file systems 
-divided across partitions on a server. When developing the “thunderdome.java” application, 
-competition to the death would be an exciting feature. For all other applications, it’s 
-important that the heap not clobber the permanent space in its quest for one more MB. The 
-most important distinction is between conceptually guaranteed space versus a limit.  
+What’s the point of setting the 2 dozen flags for the JVM if none of them control the
+memory footprint? The purpose is to set boundaries, similar to having multiple file systems
+divided across partitions on a server. When developing the “thunderdome.java” application,
+competition to the death would be an exciting feature. For all other applications, it’s
+important that the heap not clobber the permanent space in its quest for one more MB. The
+most important distinction is between conceptually guaranteed space versus a limit. 
 
-The Kit and Caboodle
----------------------
+### The Kit and Caboodle
 
-JVM reliability, as a product of not being killed by OOM, is critical to any business 
-practice. That’s all well and good, but even the most stable applications need to be 
+JVM reliability, as a product of not being killed by OOM, is critical to any business
+practice. That’s all well and good, but even the most stable applications need to be
 restarted at times, so what does this have to do with memory efficiency?
 
-A strong recommendation by the modern JVM community is to run with equivalent settings 
-for minimum and maximum head (Xms and Xmx). That’s because front-loading the largest memory 
-resource of the JVM at start means avoiding the slow, and potentially unreliable, growth 
-from min to max. In addition to that benefit, this type of configuration also means that 
-restarting the JVM requires full memory allocation before the JVM, and its applications, 
-become functional. The gap between a 512M and 1GB head seems, and on modern systems 
-typically is, trivial. Consider, however, the time required to statically assign and address 
-4GB versus 8GB of RAM. Add in a bit of overhead for paravirtualization in the modern market 
+A strong recommendation by the modern JVM community is to run with equivalent settings
+for minimum and maximum head (Xms and Xmx). That’s because front-loading the largest memory
+resource of the JVM at start means avoiding the slow, and potentially unreliable, growth
+from min to max. In addition to that benefit, this type of configuration also means that
+restarting the JVM requires full memory allocation before the JVM, and its applications,
+become functional. The gap between a 512M and 1GB head seems, and on modern systems
+typically is, trivial. Consider, however, the time required to statically assign and address
+4GB versus 8GB of RAM. Add in a bit of overhead for paravirtualization in the modern market
 place and JVM heap size starts to look really important to maintenance operation planning.
 
-No matter how well written, tested, and supported the application, there is almost always 
-a risk of unexpected crashes and performance degradation. That’s what a thread dump is for, 
-right? In many cases, yes. While we’re considering time-to-recovery of an application, let’s 
-add in the difference between dumping 4GB of addressed memory to file against the same 8GB 
-above. The beefy 8GB application is starting to look very time-expensive under pressure, 
+No matter how well written, tested, and supported the application, there is almost always
+a risk of unexpected crashes and performance degradation. That’s what a thread dump is for,
+right? In many cases, yes. While we’re considering time-to-recovery of an application, let’s
+add in the difference between dumping 4GB of addressed memory to file against the same 8GB
+above. The beefy 8GB application is starting to look very time-expensive under pressure,
 precisely when time costs are most critical.
  
-Compartmentalize the Complexity
--------------------------------
+### Compartmentalize the Complexity
 
-If an E-Commerce store could be efficiently run in BASIC, then there would probably be a 
-market demand. Lacking the latter, it could be that more complex but comprehensive frameworks, 
+If an E-Commerce store could be efficiently run in BASIC, then there would probably be a
+market demand. Lacking the latter, it could be that more complex but comprehensive frameworks,
 such as Java, are in demand because they solve the needs of the former.
 
-Just because the goal, and comprehensive operation, of an application is very complex, 
-however, does not necessitate that a single application thread perform all functions. For 
-example, it would be very straightforward to write code to perform catalog search 
-optimization. Since the owner of SOLR already did that with their SOLR application, there is 
-seldom need to reinvent that wheel. The same principle can be applied for other operational 
+Just because the goal, and comprehensive operation, of an application is very complex,
+however, does not necessitate that a single application thread perform all functions. For
+example, it would be very straightforward to write code to perform catalog search
+optimization. Since the owner of SOLR already did that with their SOLR application, there is
+seldom need to reinvent that wheel. The same principle can be applied for other operational
 components. Probably true, but why?
 
-Density is a very important modern computing concepts: how many VMs can fit on a hypervisor? 
-How many products can squeeze into the database? How many concurrent visitors can pack into 
-the application? In large part, density is about vertical scaling. For many aspects of the 
-architecture, this is a critical sub-topic. When targeting an efficient JVM, however, there 
-is a break-even point unique to each application after which vertical scaling on the host 
-system (like adding memory resources to the heap) have diminishing incremental returns. 
+Density is a very important modern computing concepts: how many VMs can fit on a hypervisor?
+How many products can squeeze into the database? How many concurrent visitors can pack into
+the application? In large part, density is about vertical scaling. For many aspects of the
+architecture, this is a critical sub-topic. When targeting an efficient JVM, however, there
+is a break-even point unique to each application after which vertical scaling on the host
+system (like adding memory resources to the heap) have diminishing incremental returns.
 
-It’s at that point, or ideally right before, that the application begins to scale 
-horizontally instead. From a purely load-based perspective, this is very simple: *One more 
-user is beyond the threshold, so it’s time to add another server*. This same thought-exercise 
-can be applied to JVM scaling as well: *One more MB of heap will be inefficient, so it’s time 
+It’s at that point, or ideally right before, that the application begins to scale
+horizontally instead. From a purely load-based perspective, this is very simple: *One more
+user is beyond the threshold, so it’s time to add another server*. This same thought-exercise
+can be applied to JVM scaling as well: *One more MB of heap will be inefficient, so it’s time
 to add another JVM instance*.
 
-The distinction, however, is that non-load-based horizontal scaling for the JVM means a 
-division of labor. Imagine an application for ordering widget1 and widget2 from a catalog. 
-At first, a single JVM can efficiently manage the entire order process. As the 
-market for widgets expands it becomes necessary to distinguish between visitors and 
-conversions (sessions that are only browsing the catalog versus sessions that are in 
-the process of placing an order). Extending the thought-exercise further, when demand becomes 
-so great that a single JVM cannot manage the catalog for both widget1 and widget2, then an 
-optimization can be sought for more specific functional compartmentalization focused on each 
+The distinction, however, is that non-load-based horizontal scaling for the JVM means a
+division of labor. Imagine an application for ordering widget1 and widget2 from a catalog.
+At first, a single JVM can efficiently manage the entire order process. As the
+market for widgets expands it becomes necessary to distinguish between visitors and
+conversions (sessions that are only browsing the catalog versus sessions that are in
+the process of placing an order). Extending the thought-exercise further, when demand becomes
+so great that a single JVM cannot manage the catalog for both widget1 and widget2, then an
+optimization can be sought for more specific functional compartmentalization focused on each
 widget individually.
  
-Bring ‘em home, Casey
----------------------
+### Bring ‘em home, Casey
 
-As the vehicles to develop and deliver software solutions become more complex, which shows 
-no sign of slowing, the surface for introducing inefficiencies continues to expand. Doomsday 
-predictions aside, the most important question to ask during the development and support 
+As the vehicles to develop and deliver software solutions become more complex, which shows
+no sign of slowing, the surface for introducing inefficiencies continues to expand. Doomsday
+predictions aside, the most important question to ask during the development and support
 lifecycles is “why?”:
 
 * Why does the software require 8GB of RAM instead of 4GB?
 * Why does it take 45 minutes to restart the cart application?
 * Why is it so hard to find the source of a problem from a thread dump?
  
-TL;DR – start as small as possible without compromising performance, then try to perform 
+TL;DR – start as small as possible without compromising performance, then try to perform
 when smaller than that.
  
 Good Luck!

--- a/_posts/2015-11-18-JVM-Importance-of-Sizing.md
+++ b/_posts/2015-11-18-JVM-Importance-of-Sizing.md
@@ -1,12 +1,11 @@
 ---
 layout: post
-title: "Your JVM – The Importance of Sizing"
-date: 2015-11-18 10:00
+title: Your JVM – The Importance of Sizing
+date: '2015-11-18 10:00'
 comments: true
 author: Jonathan Hurley
 published: true
-categories:
-    - Ecommerce
+categories: []
 ---
 
 In the good old days the measure of a programmer was efficiency - how much functionality

--- a/_posts/2015-12-02-A-First-Look-at-RBAC-in-the-Liberty-Release-of-Neutron.md
+++ b/_posts/2015-12-02-A-First-Look-at-RBAC-in-the-Liberty-Release-of-Neutron.md
@@ -1,14 +1,14 @@
 ---
 layout: post
-title: "A First Look at RBAC in the Liberty Release of Neutron"
-date: 2015-12-02 00:00:00
+title: A First Look at RBAC in the Liberty Release of Neutron
+date: 2015-12-02T00:00:00.000Z
 comments: false
 author: James Denton
 published: true
 categories:
-    - neutron
-    - rpc
-    - openstack
+  - neutron
+  - rpc
+  - openstack
 ---
 
 Over the last couple of years, we've seen OpenStack deployments shift from a public cloud model, where no one is trusted, to a private cloud model, where collaboration and shared resources between projects is required. As enterprises adopt OpenStack and integrate it into their infrastructure, new use cases continue to multiply, and existing limitations in APIs and data models have been brought to the forefront. One of the more exciting features to come out of Neutron development in the Liberty cycle that addresses a shortcoming is a framework for Role Based Access Control (RBAC).

--- a/_posts/2015-12-08-VMSS-With-AutoScale-And-IIS.md
+++ b/_posts/2015-12-08-VMSS-With-AutoScale-And-IIS.md
@@ -1,14 +1,11 @@
 ---
 layout: post
-title: "VMSS With AutoScale And IIS"
-date: 2015-12-04 10:45
+title: VMSS With AutoScale And IIS
+date: '2015-12-04 10:45'
 comments: false
 author: Jimmy Rudley
 published: true
-categories:
-    - Azure
-    - VMSS
-    - Autoscale
+categories: []
 ---
 
 Virtual Machine Scale Sets, which was recently released in preview from Microsoft, lets you manage a set of virtual machines as one. 

--- a/_posts/2015-12-14-AEM6.1-With-MongoDB-3.0-And-WiredTiger.md
+++ b/_posts/2015-12-14-AEM6.1-With-MongoDB-3.0-And-WiredTiger.md
@@ -1,15 +1,12 @@
 ---
 layout: post
-title: "AEM 6.1 With MongoDB 3.0 and WiredTiger"
-date: 2015-12-14 23:59
+title: AEM 6.1 With MongoDB 3.0 and WiredTiger
+date: '2015-12-14 23:59'
 comments: true
 author: Nathan Coble
 authorIsRacker: true
 published: true
-categories:
-    - AEM
-    - mongo
-    - CMS
+categories: []
 ---
 # AEM 6.1 With MongoDB 3.0 and WiredTiger
 Adobe, with the release of AEM 6.1, [officially supports][adobe1] MongoDB 3.0 and its plugabble engine WiredTiger. This post will take you through installing and configuring AEM 6.1 and MongoDB to take advatange of [performance improvements in MongoDB 3.0.][or1]

--- a/_posts/2015-12-15-a-tutorial-on-application-development-using-vagrant-with-the-pycharm-ide.md
+++ b/_posts/2015-12-15-a-tutorial-on-application-development-using-vagrant-with-the-pycharm-ide.md
@@ -1,14 +1,13 @@
 ---
 layout: post
-title: "A Tutorial on Application Development Using Vagrant with the PyCharm IDE"
-date: 2015-12-15 23:59
+title: A Tutorial on Application Development Using Vagrant with the PyCharm IDE
+date: '2015-12-15 23:59'
 comments: false
 author: Brandon Griffin
 authorIsRacker: true
 published: true
 categories:
-- Vagrant
-- Python
+  - Python
 ---
 I have spent the majority of my career as a Java developer.  As a result, I learned to be more productive using an IDE instead of an editor like Vi.  Even though Vi is still my editor of choice when I’m in a Linux shell, I don’t believe it’s practical when managing large Java projects. 
 

--- a/_posts/2015-12-16-run-sitecore-in-a-docker-container-on-windows-server-2016.md
+++ b/_posts/2015-12-16-run-sitecore-in-a-docker-container-on-windows-server-2016.md
@@ -1,14 +1,12 @@
 ---
 layout: post
-title: "Run Sitecore in a Docker container on Windows Server 2016"
-date: 2015-12-16 10:45
+title: Run Sitecore in a Docker container on Windows Server 2016
+date: '2015-12-16 10:45'
 comments: false
 author: Jimmy Rudley
 published: true
 categories:
-    - Windows Server 2016 Technical Preview 4
-    - Docker
-    - Sitecore
+  - Docker
 ---
 
 At SUGCON 2015, Rackspace and Hedgehog presented about how using Docker will shape the way we work with Sitecore, an ASP.Net web content management system. With the release of Windows Server 2016 Technical Preview 4, we are now able to run Sitecore in a Docker container. 

--- a/script/audit-blog
+++ b/script/audit-blog
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+/**
+ * A script to be invoked from the shell that does various auditing activities
+ *
+ * @requires lodash
+ * @requires commander
+ * @requires glob
+ * @requires front-matter
+ * @requires natural
+ * @requires slug
+ * @requires simple-statistics
+ * @requires js-yaml
+ */
+
+var path = require('path');
+var fs = require('fs');
+var _ = require('lodash');
+var program = require('commander');
+var glob = require('glob');
+var frontmatter = require('front-matter');
+var natural = require('natural');
+var slug = require('slug');
+var stats = require('simple-statistics');
+var yaml = require('js-yaml');
+
+// This is where all the blog posts are
+var POST_DIR = path.resolve(__dirname, '../_posts');
+
+// A number between 0 and 100, reflecting the percentage of all posts that
+// be included in a category for it to be deemed "full enough".
+var UNDERUSED_THRESHOLD = 2;
+
+// A number between 0 and 1. Categories with a Jaro-Winkler distance above this
+// value will be considered similar enough to be combined
+var SIMILARITY_INDEX = 0.9;
+
+
+program.on('--help', function () {
+  console.log('  Commands:');
+  console.log('     categories list-underused    Show categories for which the number of posts is <= ' + UNDERUSED_THRESHOLD + '% of all posts');
+  console.log('     categories delete-underused  Remove underused categories from applicable posts');
+  console.log('     categories list-similar      Show categories that have similar names and could be normalized/merged');
+});
+
+program.parse(process.argv);
+
+// Each property of entrypoints corresponds to a top-level CLI command of the same name
+var entrypoints = {
+  // Check categories for sanity
+  categories: function () {
+    var postFiles = glob.sync(path.resolve(POST_DIR, '*'));
+    var posts = [],
+      categories = [];
+
+    var addPost = function (post) {
+      posts.push(post);
+
+      if(!post.frontmatter.categories) {
+        // TODO: Complain that post has no categories
+        return;
+      }
+
+      post.frontmatter.categories.forEach(function (category, index, array) {
+        addCategory(category);
+      });
+    };
+
+    var addCategory = function (category) {
+      var categorySlug = slug(category, {
+        separator: '-',
+        lower: true
+      });
+
+      if (_.findWhere(categories, {slug: categorySlug})) {
+        // existing is passed by reference, so we can update right here.
+        var existing = _.findWhere(categories, {slug: categorySlug});
+        existing.count = existing.count + 1;
+        return;
+      }
+
+      var catObject = {
+        name: category,
+        slug: categorySlug,
+        count: 1
+      };
+
+      categories.push(catObject);
+    };
+
+    var getFrontmatter = function (file) {
+      var contents = fs.readFileSync(file, 'utf8');
+      var frontmatter = contents.match(/^---\n([\s\S]+?)---/m);
+
+      if(!frontmatter[1]) {
+        return null;
+      }
+
+      return yaml.safeLoad(frontmatter[1], {filename: file});
+    };
+
+    var setFrontmatter = function (file, data) {
+      var contents = fs.readFileSync(file, 'utf8');
+      // Replace the existing frontmatter with our modified frontmatter
+      contents = contents.replace(/^---\n[\s\S]+?---/m, '---\n' + yaml.safeDump(data) + '---');
+      console.log('Updating frontmatter in %s', path.relative(__dirname + '/..', file));
+      fs.writeFileSync(file, contents, 'utf8');
+    };
+
+    var isCategoryUnderused = function (category) {
+      var threshold = posts.length * UNDERUSED_THRESHOLD / 100;
+
+      return category.count < threshold;
+    };
+
+    var subcommands = {
+      /**
+       * Find categories accounting for les than <UNDERUSED_THRESHOLD> percent
+       * of all posts and output them
+       */
+      'list-underused': function () {
+        var underused = [];
+
+        underused = _.filter(categories, function (category) {
+          return isCategoryUnderused(category);
+        });
+
+        underused = _.sortBy(underused, function (item) {
+          return item.count * -1;
+        });
+
+        underused.forEach(function (category) {
+          console.log('Category \'%s\' only has %s post%s', category.slug, category.count, (category.count != 1) ? 's' : '');
+        });
+      },
+
+      /**
+       * Find categories accounting for les than <UNDERUSED_THRESHOLD> percent
+       * of all posts, then find posts that are assigned to those categories and
+       * remove the underused category from the frontmatter of each.
+       *
+       * WARNING: This function could potentially modify many of your post files
+       */
+      'delete-underused': function () {
+        categories.forEach(function (category, index, array) {
+          if(!isCategoryUnderused(category)) {
+            return;
+          }
+
+          posts.forEach(function (post) {
+            // Some posts just don't have categories
+            if(!post.frontmatter.categories) {
+              return;
+            }
+
+            if(post.frontmatter.categories.indexOf(category.name) != -1) {
+              post.dirty = true;
+              post.frontmatter.categories.splice(post.frontmatter.categories.indexOf(category.name), 1);
+            }
+          });
+        });
+
+        posts.forEach(function (post) {
+          if(!post.dirty) {
+            return;
+          }
+
+          setFrontmatter(post.filename, post.frontmatter);
+        });
+      },
+
+      /**
+       * Find pairs of categories with similar slugs (>= SIMILARITY_INDEX
+       * Jaro-Winkler distance). Determine which has more posts and suggest
+       * merging the smaller category into the larger one.
+       */
+      'list-similar': function () {
+        categories.forEach(function (category, index, array) {
+          array.forEach(function (pair, pairIndex, pairArray) {
+            if (pairIndex == index || category.slug == pair.slug) {
+              return;
+            }
+
+            if (natural.JaroWinklerDistance(category.slug, pair.slug) >= SIMILARITY_INDEX) {
+              var smaller = (category.count < pair.count) ? category : pair;
+              var bigger = (category.count >= pair.count) ? category : pair;
+
+              if(isCategoryUnderused(bigger)) {
+                // Don't bother if the larger category will probably be deleted
+                return;
+              }
+
+              console.log('Consider merging category %s(%s) into %s(%s).', smaller.slug, smaller.count, bigger.slug, bigger.count);
+              console.log('Affected posts:');
+
+              posts.forEach(function (post) {
+                if(post.frontmatter.categories.indexOf(smaller.name) != -1) {
+                  console.log('  - %s', path.relative(__dirname + '/..', post.filename));
+                }
+              });
+            }
+          });
+        });
+      }
+    };
+
+    // Seed the data variables: posts and categories
+    postFiles.forEach(function (post, index, array) {
+      addPost({
+        filename: post,
+        frontmatter: getFrontmatter(post)
+      });
+    });
+
+    // Run the chosen subcommand!
+    subcommands[arguments[1]].apply(null, arguments);
+  }
+};
+
+
+// Call the entrypoint with the first argument, and pass all arguments along to that function
+// Commander probably provides a nicer way to do this.
+try {
+  entrypoints[program.args[0]].apply(null, program.args);
+}
+catch (e) {
+  program.help();
+}


### PR DESCRIPTION
1. Combined many categories that were too small into other larger, more generic categories. Discovered these by evaluating how similar the slugs of each were, so there may be some obvious optimizations that weren't caught because the slugs of two similar concepts were too different. This got rid of about 20 superfluous categories.
1. Removed categories that accounted for <= 2% of all posts. At our current corpus, this means getting rid of categories with 6 or fewer posts in them. This got rid of about 200 obscure categories.
1. _Happy side-effect:_ because I used a YAML library to load/dump the frontmatter of every post, all of our frontmatter is now fairly normalized!

All in all, we had 357 categories before and now we have just 32.

I've also included the script I used to do all this, with the hopes that we can fashion it into a build script that fails if an author tries to create random new categories with their new post. Because it's written in Node (comfort zone), It also needs the accompanying `package.json` and `node_modules` that I don't really want to cram into our current script directory. I'll probably move it out to its own NPM module that we can just install globally and run as part of a Travis/Strider job.