### PR TITLE
Override the default preparer

### DIFF
--- a/_deconst.json
+++ b/_deconst.json
@@ -1,3 +1,4 @@
 {
-  "contentIDBase": "https://github.com/rackerlabs/docs-developer-blog"
+  "contentIDBase": "https://github.com/rackerlabs/docs-developer-blog",
+  "preparer": "quay.io/smashwilson/preparer-devblog"
 }


### PR DESCRIPTION
Override the default Jekyll preparer to use [smashwilson/preparer-devblog](https://github.com/smashwilson/preparer-devblog/), which includes the Jekyll audit.

Part of #190.