### PR TITLE
Add note about moving away from pyrax

### DIFF
--- a/sdks/python/index.html
+++ b/sdks/python/index.html
@@ -17,11 +17,11 @@ title: Python SDK
     <li><a href="/docs/cloud-servers/getting-started/?lang=python">Cloud Servers</a></li>
  </ul>
 
-  <p>A unified <a href="https://wiki.openstack.org/wiki/SDK-Development/PythonOpenStackSDK">OpenStack SDK for Python</a> is in the works.</p>
+  <p><b>Note: Pyrax is in the process of being deprecated in favor of <a href="https://pypi.python.org/pypi/rackspacesdk">rackspacesdk</a>, built on the <a href="https://pypi.python.org/pypi/openstacksdk">OpenStack SDK</a>. We will announce the process and timelines for this deprecation as soon as we can.</b></p>
   <hr />
   <h2>Requirements</h2>
 
-  <p>Using <strong>pyrax</strong> requires <strong>Python 2.7.x</strong>. There are plans to port it to run in both 2.x and 3.x, but that work has not yet been started. We recommend <a href="https://pip.pypa.io/en/latest/installing.html">installing <strong>pip</strong></a> to handle all of the dependency requirements for <strong>pyrax</strong>.</p>
+  <p>Using <strong>pyrax</strong> requires <strong>Python 2.7.x</strong>. We recommend <a href="https://pip.pypa.io/en/latest/installing.html">installing <strong>pip</strong></a> to handle all of the dependency requirements for <strong>pyrax</strong>.</p>
   <h2>Installation</h2>
   <p>Generally, pyrax should be installed into a <a href="http://docs.python-guide.org/en/latest/dev/virtualenvs/">virtual environment</a> using pip:</p>
   {% highlight sh %}


### PR DESCRIPTION
Note about moving away from pyrax, and removed a mention about porting to Python 3 as that's not happening.